### PR TITLE
Modified the Readme and moved Python3 to Python2 (Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ CFLAGS = -std=c99 -Wall -Wextra `pkg-config --cflags --libs cairo`
 LDFLAGS = -lm `pkg-config --libs cairo`
 
 PNGQUANT = pngquant
-PYTHON = python3
+PYTHON = python2
 PNGQUANTFLAGS = --speed 1 --skip-if-larger --quality 85-95 --force
 BODY_DIMENSIONS = 160x160
 IMOPS := -size $(BODY_DIMENSIONS) canvas:none -compose copy -gravity center

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ The code provided is for educational purposes only. Apple is a trademark of Appl
   - On the command line, enter: `python -m pip install https://github.com/googlefonts/nototools/archive/v0.2.1.tar.gz`, or
     clone a copy from https://github.com/googlei18n/nototools and either put it in your PYTHONPATH or use `python setup.py
     develop` ('install' currently won't fully install all the data used by nototools).
-- Install [Optipng](http://optipng.sourceforge.net/), [Zopfli](https://github.com/google/zopfli) and [Pngquant](https://pngquant.org/).
-  - On RedHat based systems, run `yum install optipng zopfli pngquant`
-  - Or on Fedora, run `dnf install optipng zopfli pngquant`
-  - If you're using Debian or Ubuntu, you may run `apt-get install optipng zopfli pngquant` at the command line.
+- Install [Optipng](http://optipng.sourceforge.net/), [Zopfli](https://github.com/google/zopfli), [Pngquant](https://pngquant.org/) and [ImageMagick](https://imagemagick.org/).
+  - On RedHat based systems, run `yum install optipng zopfli pngquant imagemagick`
+  - Or on Fedora, run `dnf install optipng zopfli pngquant ImageMagick`
+  - If you're using Debian or Ubuntu, you may run `apt-get install optipng zopfli pngquant imagemagick` at the command line.
 - Clone the [source repository](https://github.com/samuelngs/apple-emoji-linux) from Github
 - Open a terminal or console prompt, change to the directory where you cloned `apple-emoji-linux`, and type `make -j` to build `AppleColorEmoji.ttf` from source.
 - If you wish to install the built `AppleColorEmoji.ttf` to your system, execute `make install`,


### PR DESCRIPTION
I added ImageMagick in the [readme](https://github.com/Bebebole/apple-emoji-linux/blob/ios-15.4/README.md) because you can't build the font without it, and i changed python3 to python2 in the [makefile](https://github.com/Bebebole/apple-emoji-linux/blob/ios-15.4/Makefile) because we're using python2 for that.