### PR TITLE
Fix source build instructions, add `flake.nix`, project-wide format

### DIFF
--- a/.git-ignore-revs
+++ b/.git-ignore-revs
@@ -1,0 +1,2 @@
+# nix fmt
+44348b91a978b5c90d22ce1af9b2b8edff79e14d

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,34 +1,29 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
-
 name: Build Apple Color Emoji font
-
 on: pull_request
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.9
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install fonttools
-        python -m pip install notofonttools
-        sudo apt-get update
-        sudo apt-get install --yes optipng zopfli pngquant
-    - name: Build Apple color emoji font
-      run: |
-        make -j
-        make install
-    - name: Archive build artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: apple-color-emoji-font
-        path: AppleColorEmoji.ttf
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install fonttools
+          python -m pip install notofonttools
+          sudo apt-get update
+          sudo apt-get install --yes optipng zopfli pngquant
+      - name: Build Apple color emoji font
+        run: |
+          make -j
+          make install
+      - name: Archive build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: apple-color-emoji-font
+          path: AppleColorEmoji.ttf

--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,5 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Apple Color Emoji for Linux
 
-Welcome to the world of colorful emojis on your Linux system! 🌈 This project brings Apple's vibrant emojis to your Linux experience. 
+Welcome to the world of colorful emojis on your Linux system! 🌈 This project brings Apple's vibrant emojis to your Linux experience.
 
 ## Disclaimer
 
@@ -15,19 +15,30 @@ Welcome to the world of colorful emojis on your Linux system! 🌈 This project 
 - 🔄 Rebuild the font cache with `fc-cache -f -v`.
 - 🎉 Voila! You're all set to embrace the world of expressive emojis!
 
-## 🛠 Building AppleColorEmoji from Source
+## 🛠 Building AppleColorEmoji from source
 
-- 🐍 Install Python 2; the process currently requires a Python 2.x wide build.
+You can decide to use the provided [flake.nix](./flake.nix) to automatically get the dependencies, or install the dependencies manually on your system and build from source:
+
+### Manually installing dependencies
+
+- 🐍 Install Python 3; the process currently requires a Python 3.x wide build.
 - 📦 Install the [fonttools Python package](https://github.com/fonttools/fonttools): `python -m pip install fonttools`
 - 📦 Install the [nototools Python package](https://github.com/googlei18n/nototools): `python -m pip install https://github.com/googlefonts/nototools/archive/v0.2.1.tar.gz`, or clone from [here](https://github.com/googlei18n/nototools) and follow the instructions.
-- 🛠 Install image optimization tools: [Optipng](http://optipng.sourceforge.net/), [Zopfli](https://github.com/google/zopfli), and [Pngquant](https://pngquant.org/).
-  - On RedHat-based systems: `yum install optipng zopfli pngquant`
-  - On Fedora: `dnf install optipng zopfli pngquant`
-  - On Debian or Ubuntu: `apt-get install optipng zopfli pngquant`
-- 🔄 Clone the [source repository](https://github.com/samuelngs/apple-emoji-linux) from Github.
+- 🛠 Install image optimization tools: [Optipng](http://optipng.sourceforge.net/), [Zopfli](https://github.com/google/zopfli), [Pngquant](https://pngquant.org/), and [ImageMagick](https://www.imagemagick.org/).
+  - On RedHat-based systems: `yum install optipng zopfli pngquant imagemagick`
+  - On Fedora: `dnf install optipng zopfli pngquant imagemagick`
+  - On Debian or Ubuntu: `apt-get install optipng zopfli pngquant imagemagick`
+- 🔄 Clone the [source repository](https://github.com/samuelngs/apple-emoji-linux) from GitHub.
 - 🖥 Open a terminal, navigate to the directory, and type `make -j` to build `AppleColorEmoji.ttf` from source.
 - ⚙️ To install the built `AppleColorEmoji.ttf` to your system, run `make install`.
 - 🔄 Rebuild your system font cache with `fc-cache -f -v`.
+
+### Using Nix
+
+- Install Nix and ensure flakes are enabled (look for `experimental-features = nix-command flakes` in your `nix.conf`). You can use the [Lix installer](https://lix.systems/install/) if you do not already have a working Nix install.
+- Clone the [source repository](https://github.com/samuelngs/apple-emoji-linux) from GitHub.
+- Navigate to the directory in a terminal and run `nix build` to start the build.
+- The built `AppleColorEmoji.ttf` will be in the `./result/share/fonts/truetype` folder.
 
 ## 🌟 Using AppleColorEmoji
 

--- a/add_aliases.py
+++ b/add_aliases.py
@@ -32,193 +32,235 @@ create canonically named aliases/copies, if requested."""
 
 DATA_ROOT = path.dirname(path.abspath(__file__))
 
+
 def str_to_seq(seq_str):
-  res = [int(s, 16) for s in seq_str.split('_')]
-  if 0xfe0f in res:
-    print('0xfe0f in file name: %s' % seq_str)
-    res = [x for x in res if x != 0xfe0f]
-  return tuple(res)
+    res = [int(s, 16) for s in seq_str.split("_")]
+    if 0xFE0F in res:
+        print("0xfe0f in file name: %s" % seq_str)
+        res = [x for x in res if x != 0xFE0F]
+    return tuple(res)
 
 
 def seq_to_str(seq):
-  return '_'.join('%04x' % cp for cp in seq)
+    return "_".join("%04x" % cp for cp in seq)
 
 
 def read_default_unknown_flag_aliases():
-  unknown_flag_path = path.join(DATA_ROOT, 'unknown_flag_aliases.txt')
-  return read_emoji_aliases(unknown_flag_path)
+    unknown_flag_path = path.join(DATA_ROOT, "unknown_flag_aliases.txt")
+    return read_emoji_aliases(unknown_flag_path)
 
 
 def read_default_emoji_aliases():
-  alias_path = path.join(DATA_ROOT, 'emoji_aliases.txt')
-  return read_emoji_aliases(alias_path)
+    alias_path = path.join(DATA_ROOT, "emoji_aliases.txt")
+    return read_emoji_aliases(alias_path)
 
 
 def read_emoji_aliases(filename):
-  result = {}
+    result = {}
 
-  with open(filename, 'r') as f:
-    for line in f:
-      ix = line.find('#')
-      if (ix > -1):
-        line = line[:ix]
-      line = line.strip()
-      if not line:
-        continue
-      als, trg = (s.strip() for s in line.split(';'))
-      try:
-        als_seq = tuple([int(x, 16) for x in als.split('_')])
-        trg_seq = tuple([int(x, 16) for x in trg.split('_')])
-      except:
-        print('cannot process alias %s -> %s' % (als, trg))
-        continue
-      result[als_seq] = trg_seq
-  return result
+    with open(filename, "r") as f:
+        for line in f:
+            ix = line.find("#")
+            if ix > -1:
+                line = line[:ix]
+            line = line.strip()
+            if not line:
+                continue
+            als, trg = (s.strip() for s in line.split(";"))
+            try:
+                als_seq = tuple([int(x, 16) for x in als.split("_")])
+                trg_seq = tuple([int(x, 16) for x in trg.split("_")])
+            except:
+                print("cannot process alias %s -> %s" % (als, trg))
+                continue
+            result[als_seq] = trg_seq
+    return result
 
 
 def add_aliases(
-    srcdir, dstdir, aliasfile, prefix, ext, replace=False, copy=False,
-    canonical_names=False, dry_run=False):
-  """Use aliasfile to create aliases of files in srcdir matching prefix/ext in
-  dstdir.  If dstdir is null, use srcdir as dstdir.  If replace is false
-  and a file already exists in dstdir, report and do nothing.  If copy is false
-  create a symlink, else create a copy.
+    srcdir,
+    dstdir,
+    aliasfile,
+    prefix,
+    ext,
+    replace=False,
+    copy=False,
+    canonical_names=False,
+    dry_run=False,
+):
+    """Use aliasfile to create aliases of files in srcdir matching prefix/ext in
+    dstdir.  If dstdir is null, use srcdir as dstdir.  If replace is false
+    and a file already exists in dstdir, report and do nothing.  If copy is false
+    create a symlink, else create a copy.
 
-  If canonical_names is true, check all source files and generate aliases/copies
-  using the canonical name if different from the existing name.
+    If canonical_names is true, check all source files and generate aliases/copies
+    using the canonical name if different from the existing name.
 
-  If dry_run is true, report what would be done.  Dstdir will be created if
-  necessary, even if dry_run is true."""
+    If dry_run is true, report what would be done.  Dstdir will be created if
+    necessary, even if dry_run is true."""
 
-  if not path.isdir(srcdir):
-    print('%s is not a directory' % srcdir, file=sys.stderr)
-    return
+    if not path.isdir(srcdir):
+        print("%s is not a directory" % srcdir, file=sys.stderr)
+        return
 
-  if not dstdir:
-    dstdir = srcdir
-  elif not path.isdir(dstdir):
-    os.makedirs(dstdir)
+    if not dstdir:
+        dstdir = srcdir
+    elif not path.isdir(dstdir):
+        os.makedirs(dstdir)
 
-  prefix_len = len(prefix)
-  suffix_len = len(ext) + 1
-  filenames = [path.basename(f)
-               for f in glob.glob(path.join(srcdir, '%s*.%s' % (prefix, ext)))]
-  seq_to_file = {
-      str_to_seq(name[prefix_len:-suffix_len]) : name
-      for name in filenames}
+    prefix_len = len(prefix)
+    suffix_len = len(ext) + 1
+    filenames = [
+        path.basename(f) for f in glob.glob(path.join(srcdir, "%s*.%s" % (prefix, ext)))
+    ]
+    seq_to_file = {str_to_seq(name[prefix_len:-suffix_len]): name for name in filenames}
 
-  aliases = read_emoji_aliases(aliasfile)
-  aliases_to_create = {}
-  aliases_to_replace = []
-  alias_exists = False
+    aliases = read_emoji_aliases(aliasfile)
+    aliases_to_create = {}
+    aliases_to_replace = []
+    alias_exists = False
 
-  def check_alias_seq(seq):
-    alias_str = seq_to_str(seq)
-    alias_name = '%s%s.%s' % (prefix, alias_str, ext)
-    alias_path = path.join(dstdir, alias_name)
-    if path.exists(alias_path):
-      if replace:
-        aliases_to_replace.append(alias_name)
-      else:
-        print('alias %s exists' % alias_str, file=sys.stderr)
-        alias_exists = True
-        return None
-    return alias_name
+    def check_alias_seq(seq):
+        alias_str = seq_to_str(seq)
+        alias_name = "%s%s.%s" % (prefix, alias_str, ext)
+        alias_path = path.join(dstdir, alias_name)
+        if path.exists(alias_path):
+            if replace:
+                aliases_to_replace.append(alias_name)
+            else:
+                print("alias %s exists" % alias_str, file=sys.stderr)
+                alias_exists = True
+                return None
+        return alias_name
 
-  canonical_to_file = {}
-  for als, trg in sorted(aliases.items()):
-    if trg not in seq_to_file:
-      print('target %s for %s does not exist' % (
-          seq_to_str(trg), seq_to_str(als)), file=sys.stderr)
-      continue
-    alias_name = check_alias_seq(als)
-    if alias_name:
-      target_file = seq_to_file[trg]
-      aliases_to_create[alias_name] = target_file
-      if canonical_names:
-        canonical_seq = unicode_data.get_canonical_emoji_sequence(als)
-        if canonical_seq and canonical_seq != als:
-          canonical_alias_name = check_alias_seq(canonical_seq)
-          if canonical_alias_name:
-            canonical_to_file[canonical_alias_name] = target_file
-
-  if canonical_names:
-    print('adding %d canonical aliases' % len(canonical_to_file))
-    for seq, f in seq_to_file.iteritems():
-      canonical_seq = unicode_data.get_canonical_emoji_sequence(seq)
-      if canonical_seq and canonical_seq != seq:
-        alias_name = check_alias_seq(canonical_seq)
+    canonical_to_file = {}
+    for als, trg in sorted(aliases.items()):
+        if trg not in seq_to_file:
+            print(
+                "target %s for %s does not exist" % (seq_to_str(trg), seq_to_str(als)),
+                file=sys.stderr,
+            )
+            continue
+        alias_name = check_alias_seq(als)
         if alias_name:
-          canonical_to_file[alias_name] = f
+            target_file = seq_to_file[trg]
+            aliases_to_create[alias_name] = target_file
+            if canonical_names:
+                canonical_seq = unicode_data.get_canonical_emoji_sequence(als)
+                if canonical_seq and canonical_seq != als:
+                    canonical_alias_name = check_alias_seq(canonical_seq)
+                    if canonical_alias_name:
+                        canonical_to_file[canonical_alias_name] = target_file
 
-    print('adding %d total canonical sequences' % len(canonical_to_file))
-    aliases_to_create.update(canonical_to_file)
+    if canonical_names:
+        print("adding %d canonical aliases" % len(canonical_to_file))
+        for seq, f in seq_to_file.iteritems():
+            canonical_seq = unicode_data.get_canonical_emoji_sequence(seq)
+            if canonical_seq and canonical_seq != seq:
+                alias_name = check_alias_seq(canonical_seq)
+                if alias_name:
+                    canonical_to_file[alias_name] = f
 
-  if replace:
-    if not dry_run:
-      for k in sorted(aliases_to_replace):
-        os.remove(path.join(dstdir, k))
-    print('replacing %d files' % len(aliases_to_replace))
-  elif alias_exists:
-    print('aborting, aliases exist.', file=sys.stderr)
-    return
+        print("adding %d total canonical sequences" % len(canonical_to_file))
+        aliases_to_create.update(canonical_to_file)
 
-  for k, v in sorted(aliases_to_create.items()):
-    if dry_run:
-      msg = 'replace ' if k in aliases_to_replace else ''
-      print('%s%s -> %s' % (msg, k, v))
-    else:
-      try:
-        if copy:
-          shutil.copy2(path.join(srcdir, v), path.join(dstdir, k))
+    if replace:
+        if not dry_run:
+            for k in sorted(aliases_to_replace):
+                os.remove(path.join(dstdir, k))
+        print("replacing %d files" % len(aliases_to_replace))
+    elif alias_exists:
+        print("aborting, aliases exist.", file=sys.stderr)
+        return
+
+    for k, v in sorted(aliases_to_create.items()):
+        if dry_run:
+            msg = "replace " if k in aliases_to_replace else ""
+            print("%s%s -> %s" % (msg, k, v))
         else:
-          # fix this to create relative symlinks
-          if srcdir == dstdir:
-            os.symlink(v, path.join(dstdir, k))
-          else:
-            raise Exception('can\'t create cross-directory symlinks yet')
-      except Exception as e:
-        print('failed to create %s -> %s' % (k, v), file=sys.stderr)
-        raise Exception('oops, ' + str(e))
-  print('created %d %s' % (
-      len(aliases_to_create), 'copies' if copy else 'symlinks'))
+            try:
+                if copy:
+                    shutil.copy2(path.join(srcdir, v), path.join(dstdir, k))
+                else:
+                    # fix this to create relative symlinks
+                    if srcdir == dstdir:
+                        os.symlink(v, path.join(dstdir, k))
+                    else:
+                        raise Exception("can't create cross-directory symlinks yet")
+            except Exception as e:
+                print("failed to create %s -> %s" % (k, v), file=sys.stderr)
+                raise Exception("oops, " + str(e))
+    print("created %d %s" % (len(aliases_to_create), "copies" if copy else "symlinks"))
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-s', '--srcdir', help='directory containing files to alias',
-      required=True, metavar='dir')
-  parser.add_argument(
-      '-d', '--dstdir', help='directory to write aliases, default srcdir',
-      metavar='dir')
-  parser.add_argument(
-      '-a', '--aliasfile', help='alias file (default emoji_aliases.txt)',
-      metavar='file', default='emoji_aliases.txt')
-  parser.add_argument(
-      '-p', '--prefix', help='file name prefix (default emoji_u)',
-      metavar='pfx', default='emoji_u')
-  parser.add_argument(
-      '-e', '--ext', help='file name extension (default png)',
-      choices=['ai', 'png', 'svg'], default='png')
-  parser.add_argument(
-      '-r', '--replace', help='replace existing files/aliases',
-      action='store_true')
-  parser.add_argument(
-      '-c', '--copy', help='create a copy of the file, not a symlink',
-      action='store_true')
-  parser.add_argument(
-      '--canonical_names', help='include extra copies with canonical names '
-      '(including fe0f emoji presentation character)', action='store_true');
-  parser.add_argument(
-      '-n', '--dry_run', help='print out aliases to create only',
-      action='store_true')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-s",
+        "--srcdir",
+        help="directory containing files to alias",
+        required=True,
+        metavar="dir",
+    )
+    parser.add_argument(
+        "-d",
+        "--dstdir",
+        help="directory to write aliases, default srcdir",
+        metavar="dir",
+    )
+    parser.add_argument(
+        "-a",
+        "--aliasfile",
+        help="alias file (default emoji_aliases.txt)",
+        metavar="file",
+        default="emoji_aliases.txt",
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        help="file name prefix (default emoji_u)",
+        metavar="pfx",
+        default="emoji_u",
+    )
+    parser.add_argument(
+        "-e",
+        "--ext",
+        help="file name extension (default png)",
+        choices=["ai", "png", "svg"],
+        default="png",
+    )
+    parser.add_argument(
+        "-r", "--replace", help="replace existing files/aliases", action="store_true"
+    )
+    parser.add_argument(
+        "-c",
+        "--copy",
+        help="create a copy of the file, not a symlink",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--canonical_names",
+        help="include extra copies with canonical names "
+        "(including fe0f emoji presentation character)",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-n", "--dry_run", help="print out aliases to create only", action="store_true"
+    )
+    args = parser.parse_args()
 
-  add_aliases(
-      args.srcdir, args.dstdir, args.aliasfile, args.prefix, args.ext,
-      args.replace, args.copy, args.canonical_names, args.dry_run)
+    add_aliases(
+        args.srcdir,
+        args.dstdir,
+        args.aliasfile,
+        args.prefix,
+        args.ext,
+        args.replace,
+        args.copy,
+        args.canonical_names,
+        args.dry_run,
+    )
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/add_emoji_gsub.py
+++ b/add_emoji_gsub.py
@@ -28,7 +28,7 @@ from fontTools.ttLib.tables import otTables
 from nototools import font_data
 
 
-def create_script_list(script_tag='DFLT'):
+def create_script_list(script_tag="DFLT"):
     """Create a ScriptList for the GSUB table."""
     def_lang_sys = otTables.DefaultLangSys()
     def_lang_sys.ReqFeatureIndex = 0xFFFF
@@ -84,13 +84,14 @@ def get_glyph_name_or_create(char, font):
     glyph_name = agl.UV2AGL[char]
     assert glyph_name not in font.glyphOrder
 
-    font['hmtx'].metrics[glyph_name] = [0, 0]
+    font["hmtx"].metrics[glyph_name] = [0, 0]
     cmap[char] = glyph_name
 
-    if 'glyf' in font:
+    if "glyf" in font:
         from fontTools.ttLib.tables import _g_l_y_f
+
         empty_glyph = _g_l_y_f.Glyph()
-        font['glyf'].glyphs[glyph_name] = empty_glyph
+        font["glyf"].glyphs[glyph_name] = empty_glyph
 
     font.glyphOrder.append(glyph_name)
     return glyph_name
@@ -128,10 +129,10 @@ def create_lookup(table, font, flag=0):
     return lookup
 
 
-def create_simple_gsub(lookups, script='DFLT', feature='ccmp'):
+def create_simple_gsub(lookups, script="DFLT", feature="ccmp"):
     """Create a simple GSUB table."""
-    gsub_class = ttLib.getTableClass('GSUB')
-    gsub = gsub_class('GSUB')
+    gsub_class = ttLib.getTableClass("GSUB")
+    gsub = gsub_class("GSUB")
 
     gsub.table = otTables.GSUB()
     gsub.table.Version = 1.0
@@ -142,54 +143,54 @@ def create_simple_gsub(lookups, script='DFLT', feature='ccmp'):
 
 
 def reg_indicator(letter):
-    """Return a regional indicator charater from corresponing capital letter.
-    """
-    return 0x1F1E6 + ord(letter) - ord('A')
+    """Return a regional indicator charater from corresponing capital letter."""
+    return 0x1F1E6 + ord(letter) - ord("A")
 
 
 EMOJI_FLAGS = {
-    0xFE4E5: (reg_indicator('J'), reg_indicator('P')),  # Japan
-    0xFE4E6: (reg_indicator('U'), reg_indicator('S')),  # United States
-    0xFE4E7: (reg_indicator('F'), reg_indicator('R')),  # France
-    0xFE4E8: (reg_indicator('D'), reg_indicator('E')),  # Germany
-    0xFE4E9: (reg_indicator('I'), reg_indicator('T')),  # Italy
-    0xFE4EA: (reg_indicator('G'), reg_indicator('B')),  # United Kingdom
-    0xFE4EB: (reg_indicator('E'), reg_indicator('S')),  # Spain
-    0xFE4EC: (reg_indicator('R'), reg_indicator('U')),  # Russia
-    0xFE4ED: (reg_indicator('C'), reg_indicator('N')),  # China
-    0xFE4EE: (reg_indicator('K'), reg_indicator('R')),  # Korea
+    0xFE4E5: (reg_indicator("J"), reg_indicator("P")),  # Japan
+    0xFE4E6: (reg_indicator("U"), reg_indicator("S")),  # United States
+    0xFE4E7: (reg_indicator("F"), reg_indicator("R")),  # France
+    0xFE4E8: (reg_indicator("D"), reg_indicator("E")),  # Germany
+    0xFE4E9: (reg_indicator("I"), reg_indicator("T")),  # Italy
+    0xFE4EA: (reg_indicator("G"), reg_indicator("B")),  # United Kingdom
+    0xFE4EB: (reg_indicator("E"), reg_indicator("S")),  # Spain
+    0xFE4EC: (reg_indicator("R"), reg_indicator("U")),  # Russia
+    0xFE4ED: (reg_indicator("C"), reg_indicator("N")),  # China
+    0xFE4EE: (reg_indicator("K"), reg_indicator("R")),  # Korea
 }
 
 KEYCAP = 0x20E3
 
 EMOJI_KEYCAPS = {
-    0xFE82C: (ord('#'), KEYCAP),
-    0xFE82E: (ord('1'), KEYCAP),
-    0xFE82F: (ord('2'), KEYCAP),
-    0xFE830: (ord('3'), KEYCAP),
-    0xFE831: (ord('4'), KEYCAP),
-    0xFE832: (ord('5'), KEYCAP),
-    0xFE833: (ord('6'), KEYCAP),
-    0xFE834: (ord('7'), KEYCAP),
-    0xFE835: (ord('8'), KEYCAP),
-    0xFE836: (ord('9'), KEYCAP),
-    0xFE837: (ord('0'), KEYCAP),
+    0xFE82C: (ord("#"), KEYCAP),
+    0xFE82E: (ord("1"), KEYCAP),
+    0xFE82F: (ord("2"), KEYCAP),
+    0xFE830: (ord("3"), KEYCAP),
+    0xFE831: (ord("4"), KEYCAP),
+    0xFE832: (ord("5"), KEYCAP),
+    0xFE833: (ord("6"), KEYCAP),
+    0xFE834: (ord("7"), KEYCAP),
+    0xFE835: (ord("8"), KEYCAP),
+    0xFE836: (ord("9"), KEYCAP),
+    0xFE837: (ord("0"), KEYCAP),
 }
+
 
 def main(argv):
     """Modify all the fonts given in the command line."""
     for font_name in argv[1:]:
         font = ttLib.TTFont(font_name)
 
-        assert 'GSUB' not in font
-        font['GSUB'] = create_simple_gsub([
-            create_lookup(EMOJI_KEYCAPS, font),
-            create_lookup(EMOJI_FLAGS, font)])
+        assert "GSUB" not in font
+        font["GSUB"] = create_simple_gsub(
+            [create_lookup(EMOJI_KEYCAPS, font), create_lookup(EMOJI_FLAGS, font)]
+        )
 
-        font_data.delete_from_cmap(
-            font, EMOJI_FLAGS.keys() + EMOJI_KEYCAPS.keys())
+        font_data.delete_from_cmap(font, EMOJI_FLAGS.keys() + EMOJI_KEYCAPS.keys())
 
-        font.save(font_name+'-fixed')
+        font.save(font_name + "-fixed")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main(sys.argv)

--- a/add_glyphs.py
+++ b/add_glyphs.py
@@ -22,387 +22,415 @@ from fontTools.ttLib.tables import otTables
 import add_emoji_gsub
 import add_aliases
 
-sys.path.append(
-    path.join(os.path.dirname(__file__), 'third_party', 'color_emoji'))
+sys.path.append(path.join(os.path.dirname(__file__), "third_party", "color_emoji"))
 from png import PNG
 
 
 def get_seq_to_file(image_dir, prefix, suffix):
-  """Return a mapping from codepoint sequences to files in the given directory,
-  for files that match the prefix and suffix.  File names with this prefix and
-  suffix should consist of codepoints in hex separated by underscore.  'fe0f'
-  (the codepoint of the emoji presentation variation selector) is stripped from
-  the sequence.
-  """
-  start = len(prefix)
-  limit = -len(suffix)
-  seq_to_file = {}
-  for name in os.listdir(image_dir):
-    if not (name.startswith(prefix) and name.endswith(suffix)):
-      continue
-    try:
-      cps = [int(s, 16) for s in name[start:limit].split('_')]
-      seq = tuple(cp for cp in cps if cp != 0xfe0f)
-    except:
-      raise Exception('could not parse "%s"' % name)
-    for cp in cps:
-      if not (0 <= cp <= 0x10ffff):
-        raise Exception('bad codepoint(s) in "%s"' % name)
-    if seq in seq_to_file:
-      raise Exception('duplicate sequence for "%s" in %s' % (name, image_dir))
-    seq_to_file[seq] = path.join(image_dir, name)
-  return seq_to_file
+    """Return a mapping from codepoint sequences to files in the given directory,
+    for files that match the prefix and suffix.  File names with this prefix and
+    suffix should consist of codepoints in hex separated by underscore.  'fe0f'
+    (the codepoint of the emoji presentation variation selector) is stripped from
+    the sequence.
+    """
+    start = len(prefix)
+    limit = -len(suffix)
+    seq_to_file = {}
+    for name in os.listdir(image_dir):
+        if not (name.startswith(prefix) and name.endswith(suffix)):
+            continue
+        try:
+            cps = [int(s, 16) for s in name[start:limit].split("_")]
+            seq = tuple(cp for cp in cps if cp != 0xFE0F)
+        except:
+            raise Exception('could not parse "%s"' % name)
+        for cp in cps:
+            if not (0 <= cp <= 0x10FFFF):
+                raise Exception('bad codepoint(s) in "%s"' % name)
+        if seq in seq_to_file:
+            raise Exception('duplicate sequence for "%s" in %s' % (name, image_dir))
+        seq_to_file[seq] = path.join(image_dir, name)
+    return seq_to_file
 
 
 def collect_seq_to_file(image_dirs, prefix, suffix):
-  """Return a sequence to file mapping by calling get_seq_to_file on a list
-  of directories.  When sequences for files in later directories match those
-  from earlier directories, the later file replaces the earlier one.
-  """
-  seq_to_file = {}
-  for image_dir in image_dirs:
-    seq_to_file.update(get_seq_to_file(image_dir, prefix, suffix))
-  return seq_to_file
+    """Return a sequence to file mapping by calling get_seq_to_file on a list
+    of directories.  When sequences for files in later directories match those
+    from earlier directories, the later file replaces the earlier one.
+    """
+    seq_to_file = {}
+    for image_dir in image_dirs:
+        seq_to_file.update(get_seq_to_file(image_dir, prefix, suffix))
+    return seq_to_file
 
 
 def remap_values(seq_to_file, map_fn):
-  return {k: map_fn(v) for k, v in seq_to_file.items()}
+    return {k: map_fn(v) for k, v in seq_to_file.items()}
 
 
 def get_png_file_to_advance_mapper(lineheight):
-  def map_fn(filename):
-    wid, ht = PNG(filename).get_size()
-    return int(round(float(lineheight) * wid / ht))
-  return map_fn
+    def map_fn(filename):
+        wid, ht = PNG(filename).get_size()
+        return int(round(float(lineheight) * wid / ht))
+
+    return map_fn
 
 
 def cp_name(cp):
-  """return uniXXXX or uXXXXX(X) as a name for the glyph mapped to this cp."""
-  return '%s%04X' % ('u' if cp > 0xffff else 'uni', cp)
+    """return uniXXXX or uXXXXX(X) as a name for the glyph mapped to this cp."""
+    return "%s%04X" % ("u" if cp > 0xFFFF else "uni", cp)
 
 
 def seq_name(seq):
-  """Sequences of length one get the cp_name.  Others start with 'u' followed by
-  two or more 4-to-6-digit hex strings separated by underscore."""
-  if len(seq) == 1:
-    return cp_name(seq[0])
-  return 'u' + '_'.join('%04X' % cp for cp in seq)
+    """Sequences of length one get the cp_name.  Others start with 'u' followed by
+    two or more 4-to-6-digit hex strings separated by underscore."""
+    if len(seq) == 1:
+        return cp_name(seq[0])
+    return "u" + "_".join("%04X" % cp for cp in seq)
 
 
 def collect_cps(seqs):
-  cps = set()
-  for seq in seqs:
-    cps.update(seq)
-  return cps
+    cps = set()
+    for seq in seqs:
+        cps.update(seq)
+    return cps
 
 
 def get_glyphorder_cps_and_truncate(glyphOrder):
-  """This scans glyphOrder for names that correspond to a single codepoint
-  using the 'u(ni)XXXXXX' syntax.  All names that don't match are moved
-  to the front the glyphOrder list in their original order, and the
-  list is truncated.  The ones that do match are returned as a set of
-  codepoints."""
-  glyph_name_re = re.compile(r'^u(?:ni)?([0-9a-fA-F]{4,6})$')
-  cps = set()
-  write_ix = 0
-  for ix, name in enumerate(glyphOrder):
-    m = glyph_name_re.match(name)
-    if m:
-      cps.add(int(m.group(1), 16))
-    else:
-      glyphOrder[write_ix] = name
-      write_ix += 1
-  del glyphOrder[write_ix:]
-  return cps
+    """This scans glyphOrder for names that correspond to a single codepoint
+    using the 'u(ni)XXXXXX' syntax.  All names that don't match are moved
+    to the front the glyphOrder list in their original order, and the
+    list is truncated.  The ones that do match are returned as a set of
+    codepoints."""
+    glyph_name_re = re.compile(r"^u(?:ni)?([0-9a-fA-F]{4,6})$")
+    cps = set()
+    write_ix = 0
+    for ix, name in enumerate(glyphOrder):
+        m = glyph_name_re.match(name)
+        if m:
+            cps.add(int(m.group(1), 16))
+        else:
+            glyphOrder[write_ix] = name
+            write_ix += 1
+    del glyphOrder[write_ix:]
+    return cps
 
 
 def get_all_seqs(font, seq_to_advance):
-  """Copies the sequences from seq_to_advance and extends it with single-
-  codepoint sequences from the GlyphOrder table as well as those internal
-  to sequences in seq_to_advance.  Reduces the GlyphOrder table. """
+    """Copies the sequences from seq_to_advance and extends it with single-
+    codepoint sequences from the GlyphOrder table as well as those internal
+    to sequences in seq_to_advance.  Reduces the GlyphOrder table."""
 
-  all_seqs = set(seq_to_advance.keys())
-  # using collect_cps includes cps internal to a seq
-  cps = collect_cps(all_seqs)
-  glyphOrder = font.getGlyphOrder()
-  # extract cps in glyphOrder and reduce glyphOrder to only those that remain
-  glyphOrder_cps = get_glyphorder_cps_and_truncate(glyphOrder)
-  cps.update(glyphOrder_cps)
-  # add new single codepoint sequences from glyphOrder and sequences
-  all_seqs.update((cp,) for cp in cps)
-  return all_seqs
+    all_seqs = set(seq_to_advance.keys())
+    # using collect_cps includes cps internal to a seq
+    cps = collect_cps(all_seqs)
+    glyphOrder = font.getGlyphOrder()
+    # extract cps in glyphOrder and reduce glyphOrder to only those that remain
+    glyphOrder_cps = get_glyphorder_cps_and_truncate(glyphOrder)
+    cps.update(glyphOrder_cps)
+    # add new single codepoint sequences from glyphOrder and sequences
+    all_seqs.update((cp,) for cp in cps)
+    return all_seqs
 
 
 def get_font_cmap(font):
-  """Return the first cmap in the font, we assume it exists and is a unicode
-  cmap."""
-  return font['cmap'].tables[0].cmap
+    """Return the first cmap in the font, we assume it exists and is a unicode
+    cmap."""
+    return font["cmap"].tables[0].cmap
 
 
 def add_glyph_data(font, seqs, seq_to_advance, vadvance):
-  """Add hmtx and GlyphOrder data for all sequences in seqs, and ensures there's
-  a cmap entry for each single-codepoint sequence.  Seqs not in seq_to_advance
-  will get a zero advance."""
+    """Add hmtx and GlyphOrder data for all sequences in seqs, and ensures there's
+    a cmap entry for each single-codepoint sequence.  Seqs not in seq_to_advance
+    will get a zero advance."""
 
-  # We allow the template cmap to omit mappings for single-codepoint glyphs
-  # defined in the template's GlyphOrder table.  Similarly, the hmtx table can
-  # omit advances.  We assume glyphs named 'uniXXXX' or 'uXXXXX(X)' in the
-  # GlyphOrder table correspond to codepoints based on the name; we don't
-  # attempt to handle other types of names and these must occur in the cmap and
-  # hmtx tables in the template.
-  #
-  # seq_to_advance maps sequences (including single codepoints) to advances.
-  # All codepoints in these sequences will be added to the cmap.  Some cps
-  # in these sequences have no corresponding single-codepoint sequence, they
-  # will also get added.
-  #
-  # The added codepoints have no advance information, so will get a zero
-  # advance.
+    # We allow the template cmap to omit mappings for single-codepoint glyphs
+    # defined in the template's GlyphOrder table.  Similarly, the hmtx table can
+    # omit advances.  We assume glyphs named 'uniXXXX' or 'uXXXXX(X)' in the
+    # GlyphOrder table correspond to codepoints based on the name; we don't
+    # attempt to handle other types of names and these must occur in the cmap and
+    # hmtx tables in the template.
+    #
+    # seq_to_advance maps sequences (including single codepoints) to advances.
+    # All codepoints in these sequences will be added to the cmap.  Some cps
+    # in these sequences have no corresponding single-codepoint sequence, they
+    # will also get added.
+    #
+    # The added codepoints have no advance information, so will get a zero
+    # advance.
 
-  cmap = get_font_cmap(font)
-  hmtx = font['hmtx'].metrics
-  vmtx = font['vmtx'].metrics
+    cmap = get_font_cmap(font)
+    hmtx = font["hmtx"].metrics
+    vmtx = font["vmtx"].metrics
 
-  # We don't expect sequences to be in the glyphOrder, since we removed all the
-  # single-cp sequences from it and don't expect it to already contain names
-  # corresponding to multiple-cp sequencess.  But just in case, we use
-  # reverseGlyphMap to avoid duplicating names accidentally.
+    # We don't expect sequences to be in the glyphOrder, since we removed all the
+    # single-cp sequences from it and don't expect it to already contain names
+    # corresponding to multiple-cp sequencess.  But just in case, we use
+    # reverseGlyphMap to avoid duplicating names accidentally.
 
-  updatedGlyphOrder = False
-  reverseGlyphMap = font.getReverseGlyphMap()
+    updatedGlyphOrder = False
+    reverseGlyphMap = font.getReverseGlyphMap()
 
-  # Order the glyphs by grouping all the single-codepoint sequences first,
-  # then order by sequence so that related sequences are together.  We group
-  # by single-codepoint sequence first in order to keep these glyphs together--
-  # they're used in the coverage tables for some of the substitutions, and
-  # those tables can be more compact this way.
-  for seq in sorted(seqs, key=lambda s: (0 if len(s) == 1 else 1, s)):
-    name = seq_name(seq)
-    if len(seq) == 1:
-      cmap[seq[0]] = name
-    advance = seq_to_advance.get(seq, 0)
-    hmtx[name] = [advance, 0]
-    vmtx[name] = [vadvance, 0]
-    if name not in reverseGlyphMap:
-      font.glyphOrder.append(name)
-      updatedGlyphOrder=True
+    # Order the glyphs by grouping all the single-codepoint sequences first,
+    # then order by sequence so that related sequences are together.  We group
+    # by single-codepoint sequence first in order to keep these glyphs together--
+    # they're used in the coverage tables for some of the substitutions, and
+    # those tables can be more compact this way.
+    for seq in sorted(seqs, key=lambda s: (0 if len(s) == 1 else 1, s)):
+        name = seq_name(seq)
+        if len(seq) == 1:
+            cmap[seq[0]] = name
+        advance = seq_to_advance.get(seq, 0)
+        hmtx[name] = [advance, 0]
+        vmtx[name] = [vadvance, 0]
+        if name not in reverseGlyphMap:
+            font.glyphOrder.append(name)
+            updatedGlyphOrder = True
 
-  if updatedGlyphOrder:
-    delattr(font, '_reverseGlyphOrderDict')
+    if updatedGlyphOrder:
+        delattr(font, "_reverseGlyphOrderDict")
 
 
 def add_aliases_to_cmap(font, aliases):
-  """Some aliases might map a single codepoint to some other sequence.  These
-  should map directly to the glyph for that sequence in the cmap.  (Others will
-  map via GSUB).
-  """
-  if not aliases:
-    return
+    """Some aliases might map a single codepoint to some other sequence.  These
+    should map directly to the glyph for that sequence in the cmap.  (Others will
+    map via GSUB).
+    """
+    if not aliases:
+        return
 
-  cp_aliases = [seq for seq in aliases if len(seq) == 1]
-  if not cp_aliases:
-    return
+    cp_aliases = [seq for seq in aliases if len(seq) == 1]
+    if not cp_aliases:
+        return
 
-  cmap = get_font_cmap(font)
-  for src_seq in cp_aliases:
-    cp = src_seq[0]
-    name = seq_name(aliases[src_seq])
-    cmap[cp] = name
+    cmap = get_font_cmap(font)
+    for src_seq in cp_aliases:
+        cp = src_seq[0]
+        name = seq_name(aliases[src_seq])
+        cmap[cp] = name
 
 
 def get_rtl_seq(seq):
-  """Return the rtl variant of the sequence, if it has one, else the empty
-  sequence.
-  """
-  # Sequences with ZWJ in them will reflect.  Fitzpatrick modifiers
-  # however do not, so if we reflect we make a pass to swap them back into their
-  # logical order.
-  # Used to check for TAG_END 0xe007f as well but Android fontchain_lint
-  # dislikes the resulting mangling of flags for England, Scotland, Wales.
+    """Return the rtl variant of the sequence, if it has one, else the empty
+    sequence.
+    """
+    # Sequences with ZWJ in them will reflect.  Fitzpatrick modifiers
+    # however do not, so if we reflect we make a pass to swap them back into their
+    # logical order.
+    # Used to check for TAG_END 0xe007f as well but Android fontchain_lint
+    # dislikes the resulting mangling of flags for England, Scotland, Wales.
 
-  ZWJ = 0x200d
-  def is_fitzpatrick(cp):
-    return 0x1f3fb <= cp <= 0x1f3ff
+    ZWJ = 0x200D
 
-  if ZWJ not in seq:
-    return ()
+    def is_fitzpatrick(cp):
+        return 0x1F3FB <= cp <= 0x1F3FF
 
-  rev_seq = list(seq)
-  rev_seq.reverse()
-  for i in range(1, len(rev_seq)):
-    if is_fitzpatrick(rev_seq[i-1]):
-      tmp = rev_seq[i]
-      rev_seq[i] = rev_seq[i-1]
-      rev_seq[i-1] = tmp
-  return tuple(rev_seq)
+    if ZWJ not in seq:
+        return ()
+
+    rev_seq = list(seq)
+    rev_seq.reverse()
+    for i in range(1, len(rev_seq)):
+        if is_fitzpatrick(rev_seq[i - 1]):
+            tmp = rev_seq[i]
+            rev_seq[i] = rev_seq[i - 1]
+            rev_seq[i - 1] = tmp
+    return tuple(rev_seq)
 
 
 def get_gsub_ligature_lookup(font):
-  """If the font does not have a GSUB table, create one with a ligature
-  substitution lookup.  If it does, ensure the first lookup is a properly
-  initialized ligature substitution lookup.  Return the lookup."""
+    """If the font does not have a GSUB table, create one with a ligature
+    substitution lookup.  If it does, ensure the first lookup is a properly
+    initialized ligature substitution lookup.  Return the lookup."""
 
-  # The template might include more lookups after lookup 0, if it has a
-  # GSUB table.
-  if 'GSUB' not in font:
-    ligature_subst = otTables.LigatureSubst()
-    ligature_subst.ligatures = {}
+    # The template might include more lookups after lookup 0, if it has a
+    # GSUB table.
+    if "GSUB" not in font:
+        ligature_subst = otTables.LigatureSubst()
+        ligature_subst.ligatures = {}
 
-    lookup = otTables.Lookup()
-    lookup.LookupType = 4
-    lookup.LookupFlag = 0
-    lookup.SubTableCount = 1
-    lookup.SubTable = [ligature_subst]
+        lookup = otTables.Lookup()
+        lookup.LookupType = 4
+        lookup.LookupFlag = 0
+        lookup.SubTableCount = 1
+        lookup.SubTable = [ligature_subst]
 
-    font['GSUB'] = add_emoji_gsub.create_simple_gsub([lookup])
-  else:
-    lookup = font['GSUB'].table.LookupList.Lookup[0]
-    assert lookup.LookupFlag == 0
+        font["GSUB"] = add_emoji_gsub.create_simple_gsub([lookup])
+    else:
+        lookup = font["GSUB"].table.LookupList.Lookup[0]
+        assert lookup.LookupFlag == 0
 
-    # importXML doesn't fully init GSUB structures, so help it out
-    st = lookup.SubTable[0]
-    if not hasattr(lookup, 'LookupType'):
-      assert st.LookupType == 4
-      setattr(lookup, 'LookupType', 4)
+        # importXML doesn't fully init GSUB structures, so help it out
+        st = lookup.SubTable[0]
+        if not hasattr(lookup, "LookupType"):
+            assert st.LookupType == 4
+            setattr(lookup, "LookupType", 4)
 
-    if not hasattr(st, 'ligatures'):
-      setattr(st, 'ligatures', {})
+        if not hasattr(st, "ligatures"):
+            setattr(st, "ligatures", {})
 
-  return lookup
+    return lookup
 
 
 def add_ligature_sequences(font, seqs, aliases):
-  """Add ligature sequences."""
+    """Add ligature sequences."""
 
-  seq_to_target_name = {
-      seq: seq_name(seq) for seq in seqs if len(seq) > 1}
-  if aliases:
-    seq_to_target_name.update({
-        seq: seq_name(aliases[seq]) for seq in aliases if len(seq) > 1})
-  if not seq_to_target_name:
-    return
+    seq_to_target_name = {seq: seq_name(seq) for seq in seqs if len(seq) > 1}
+    if aliases:
+        seq_to_target_name.update(
+            {seq: seq_name(aliases[seq]) for seq in aliases if len(seq) > 1}
+        )
+    if not seq_to_target_name:
+        return
 
-  rtl_seq_to_target_name = {
-      get_rtl_seq(seq): name for seq, name in seq_to_target_name.items()}
-  seq_to_target_name.update(rtl_seq_to_target_name)
-  # sequences that don't have rtl variants get mapped to the empty sequence,
-  # delete it.
-  if () in seq_to_target_name:
-    del seq_to_target_name[()]
+    rtl_seq_to_target_name = {
+        get_rtl_seq(seq): name for seq, name in seq_to_target_name.items()
+    }
+    seq_to_target_name.update(rtl_seq_to_target_name)
+    # sequences that don't have rtl variants get mapped to the empty sequence,
+    # delete it.
+    if () in seq_to_target_name:
+        del seq_to_target_name[()]
 
-  # organize by first codepoint in sequence
-  keyed_ligatures = collections.defaultdict(list)
-  for t in seq_to_target_name.items():
-    first_cp = t[0][0]
-    keyed_ligatures[first_cp].append(t)
+    # organize by first codepoint in sequence
+    keyed_ligatures = collections.defaultdict(list)
+    for t in seq_to_target_name.items():
+        first_cp = t[0][0]
+        keyed_ligatures[first_cp].append(t)
 
-  def add_ligature(lookup, cmap, seq, name):
-    # The sequences consist of codepoints, but the entries in the ligature table
-    # are glyph names.  Aliasing can give single codepoints names based on
-    # sequences (e.g. 'guardsman' with 'male guardsman') so we map the
-    # codepoints through the cmap to get the glyph names.
-    glyph_names = [cmap[cp] for cp in seq]
+    def add_ligature(lookup, cmap, seq, name):
+        # The sequences consist of codepoints, but the entries in the ligature table
+        # are glyph names.  Aliasing can give single codepoints names based on
+        # sequences (e.g. 'guardsman' with 'male guardsman') so we map the
+        # codepoints through the cmap to get the glyph names.
+        glyph_names = [cmap[cp] for cp in seq]
 
-    lig = otTables.Ligature()
-    lig.CompCount = len(seq)
-    lig.Component = glyph_names[1:]
-    lig.LigGlyph = name
+        lig = otTables.Ligature()
+        lig.CompCount = len(seq)
+        lig.Component = glyph_names[1:]
+        lig.LigGlyph = name
 
-    ligatures = lookup.SubTable[0].ligatures
-    first_name = glyph_names[0]
-    try:
-      ligatures[first_name].append(lig)
-    except KeyError:
-      ligatures[first_name] = [lig]
+        ligatures = lookup.SubTable[0].ligatures
+        first_name = glyph_names[0]
+        try:
+            ligatures[first_name].append(lig)
+        except KeyError:
+            ligatures[first_name] = [lig]
 
-  lookup = get_gsub_ligature_lookup(font)
-  cmap = get_font_cmap(font)
-  for first_cp in sorted(keyed_ligatures):
-    pairs = keyed_ligatures[first_cp]
+    lookup = get_gsub_ligature_lookup(font)
+    cmap = get_font_cmap(font)
+    for first_cp in sorted(keyed_ligatures):
+        pairs = keyed_ligatures[first_cp]
 
-    # Sort longest first, this ensures longer sequences with common prefixes
-    # are handled before shorter ones.  The secondary sort is a standard
-    # sort on the codepoints in the sequence.
-    pairs.sort(key = lambda pair: (-len(pair[0]), pair[0]))
-    for seq, name in pairs:
-      add_ligature(lookup, cmap, seq, name)
+        # Sort longest first, this ensures longer sequences with common prefixes
+        # are handled before shorter ones.  The secondary sort is a standard
+        # sort on the codepoints in the sequence.
+        pairs.sort(key=lambda pair: (-len(pair[0]), pair[0]))
+        for seq, name in pairs:
+            add_ligature(lookup, cmap, seq, name)
 
 
 def update_font_data(font, seq_to_advance, vadvance, aliases):
-  """Update the font's cmap, hmtx, GSUB, and GlyphOrder tables."""
-  seqs = get_all_seqs(font, seq_to_advance)
-  add_glyph_data(font, seqs, seq_to_advance, vadvance)
-  add_aliases_to_cmap(font, aliases)
-  add_ligature_sequences(font, seqs, aliases)
+    """Update the font's cmap, hmtx, GSUB, and GlyphOrder tables."""
+    seqs = get_all_seqs(font, seq_to_advance)
+    add_glyph_data(font, seqs, seq_to_advance, vadvance)
+    add_aliases_to_cmap(font, aliases)
+    add_ligature_sequences(font, seqs, aliases)
 
 
 def apply_aliases(seq_dict, aliases):
-  """Aliases is a mapping from sequence to replacement sequence.  We can use
-  an alias if the target is a key in the dictionary.  Furthermore, if the
-  source is a key in the dictionary, we can delete it.  This updates the
-  dictionary and returns the usable aliases."""
-  usable_aliases = {}
-  for k, v in aliases.items():
-    if v in seq_dict:
-      usable_aliases[k] = v
-      if k in seq_dict:
-        del seq_dict[k]
-  return usable_aliases
+    """Aliases is a mapping from sequence to replacement sequence.  We can use
+    an alias if the target is a key in the dictionary.  Furthermore, if the
+    source is a key in the dictionary, we can delete it.  This updates the
+    dictionary and returns the usable aliases."""
+    usable_aliases = {}
+    for k, v in aliases.items():
+        if v in seq_dict:
+            usable_aliases[k] = v
+            if k in seq_dict:
+                del seq_dict[k]
+    return usable_aliases
 
 
 def update_ttx(in_file, out_file, image_dirs, prefix, ext, aliases_file):
-  if ext != '.png':
-    raise Exception('extension "%s" not supported' % ext)
+    if ext != ".png":
+        raise Exception('extension "%s" not supported' % ext)
 
-  seq_to_file = collect_seq_to_file(image_dirs, prefix, ext)
-  if not seq_to_file:
-    raise ValueError(
-        'no sequences with prefix "%s" and extension "%s" in %s' % (
-            prefix, ext, ', '.join(image_dirs)))
+    seq_to_file = collect_seq_to_file(image_dirs, prefix, ext)
+    if not seq_to_file:
+        raise ValueError(
+            'no sequences with prefix "%s" and extension "%s" in %s'
+            % (prefix, ext, ", ".join(image_dirs))
+        )
 
-  aliases = None
-  if aliases_file:
-    aliases = add_aliases.read_emoji_aliases(aliases_file)
-    aliases = apply_aliases(seq_to_file, aliases)
+    aliases = None
+    if aliases_file:
+        aliases = add_aliases.read_emoji_aliases(aliases_file)
+        aliases = apply_aliases(seq_to_file, aliases)
 
-  font = ttx.TTFont()
-  font.importXML(in_file)
+    font = ttx.TTFont()
+    font.importXML(in_file)
 
-  lineheight = font['hhea'].ascent - font['hhea'].descent
-  map_fn = get_png_file_to_advance_mapper(lineheight)
-  seq_to_advance = remap_values(seq_to_file, map_fn)
+    lineheight = font["hhea"].ascent - font["hhea"].descent
+    map_fn = get_png_file_to_advance_mapper(lineheight)
+    seq_to_advance = remap_values(seq_to_file, map_fn)
 
-  vadvance = font['vhea'].advanceHeightMax if 'vhea' in font else lineheight
+    vadvance = font["vhea"].advanceHeightMax if "vhea" in font else lineheight
 
-  update_font_data(font, seq_to_advance, vadvance, aliases)
+    update_font_data(font, seq_to_advance, vadvance, aliases)
 
-  font.saveXML(out_file)
+    font.saveXML(out_file)
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-f', '--in_file', help='ttx input file', metavar='file', required=True)
-  parser.add_argument(
-      '-o', '--out_file', help='ttx output file', metavar='file', required=True)
-  parser.add_argument(
-      '-d', '--image_dirs', help='directories containing image files',
-      nargs='+', metavar='dir', required=True)
-  parser.add_argument(
-      '-p', '--prefix', help='file prefix (default "emoji_u")',
-      metavar='pfx', default='emoji_u')
-  parser.add_argument(
-      '-e', '--ext', help='file extension (default ".png", currently only '
-      '".png" is supported',  metavar='ext', default='.png')
-  parser.add_argument(
-      '-a', '--aliases', help='process alias table', const='emoji_aliases.txt',
-      nargs='?', metavar='file')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-f", "--in_file", help="ttx input file", metavar="file", required=True
+    )
+    parser.add_argument(
+        "-o", "--out_file", help="ttx output file", metavar="file", required=True
+    )
+    parser.add_argument(
+        "-d",
+        "--image_dirs",
+        help="directories containing image files",
+        nargs="+",
+        metavar="dir",
+        required=True,
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        help='file prefix (default "emoji_u")',
+        metavar="pfx",
+        default="emoji_u",
+    )
+    parser.add_argument(
+        "-e",
+        "--ext",
+        help='file extension (default ".png", currently only ".png" is supported',
+        metavar="ext",
+        default=".png",
+    )
+    parser.add_argument(
+        "-a",
+        "--aliases",
+        help="process alias table",
+        const="emoji_aliases.txt",
+        nargs="?",
+        metavar="file",
+    )
+    args = parser.parse_args()
 
-  update_ttx(
-      args.in_file, args.out_file, args.image_dirs, args.prefix, args.ext,
-      args.aliases)
+    update_ttx(
+        args.in_file,
+        args.out_file,
+        args.image_dirs,
+        args.prefix,
+        args.ext,
+        args.aliases,
+    )
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/check_emoji_sequences.py
+++ b/check_emoji_sequences.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 """Compare emoji image file namings against unicode property data."""
+
 from __future__ import print_function
 
 import argparse
@@ -28,436 +29,499 @@ import sys
 from nototools import unicode_data
 import add_aliases
 
-ZWJ = 0x200d
-EMOJI_VS = 0xfe0f
+ZWJ = 0x200D
+EMOJI_VS = 0xFE0F
 
-END_TAG = 0xe007f
+END_TAG = 0xE007F
+
 
 def _make_tag_set():
-  tag_set = set()
-  tag_set |= set(range(0xe0030, 0xe003a))  # 0-9
-  tag_set |= set(range(0xe0061, 0xe007b))  # a-z
-  tag_set.add(END_TAG)
-  return tag_set
+    tag_set = set()
+    tag_set |= set(range(0xE0030, 0xE003A))  # 0-9
+    tag_set |= set(range(0xE0061, 0xE007B))  # a-z
+    tag_set.add(END_TAG)
+    return tag_set
+
 
 TAG_SET = _make_tag_set()
 
 _namedata = None
 
-def seq_name(seq):
-  global _namedata
 
-  if not _namedata:
-    def strip_vs_map(seq_map):
-      return {
-          unicode_data.strip_emoji_vs(k): v
-          for k, v in seq_map.iteritems()}
-    _namedata = [
-        strip_vs_map(unicode_data.get_emoji_combining_sequences()),
-        strip_vs_map(unicode_data.get_emoji_flag_sequences()),
-        strip_vs_map(unicode_data.get_emoji_modifier_sequences()),
-        strip_vs_map(unicode_data.get_emoji_zwj_sequences()),
+def seq_name(seq):
+    global _namedata
+
+    if not _namedata:
+
+        def strip_vs_map(seq_map):
+            return {unicode_data.strip_emoji_vs(k): v for k, v in seq_map.iteritems()}
+
+        _namedata = [
+            strip_vs_map(unicode_data.get_emoji_combining_sequences()),
+            strip_vs_map(unicode_data.get_emoji_flag_sequences()),
+            strip_vs_map(unicode_data.get_emoji_modifier_sequences()),
+            strip_vs_map(unicode_data.get_emoji_zwj_sequences()),
         ]
 
-  if len(seq) == 1:
-    return unicode_data.name(seq[0], None)
+    if len(seq) == 1:
+        return unicode_data.name(seq[0], None)
 
-  for data in _namedata:
-    if seq in data:
-      return data[seq]
-  if EMOJI_VS in seq:
-    non_vs_seq = unicode_data.strip_emoji_vs(seq)
     for data in _namedata:
-      if non_vs_seq in data:
-        return data[non_vs_seq]
+        if seq in data:
+            return data[seq]
+    if EMOJI_VS in seq:
+        non_vs_seq = unicode_data.strip_emoji_vs(seq)
+        for data in _namedata:
+            if non_vs_seq in data:
+                return data[non_vs_seq]
 
-  return None
+    return None
 
 
 def _check_no_vs(sorted_seq_to_filepath):
-  """Our image data does not use emoji presentation variation selectors."""
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    if EMOJI_VS in seq:
-      print('check no VS: FE0F in path: %s' % fp)
+    """Our image data does not use emoji presentation variation selectors."""
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        if EMOJI_VS in seq:
+            print("check no VS: FE0F in path: %s" % fp)
 
 
 def _check_valid_emoji_cps(sorted_seq_to_filepath, unicode_version):
-  """Ensure all cps in these sequences are valid emoji cps or specific cps
-  used in forming emoji sequences.  This is a 'pre-check' that reports
-  this specific problem."""
+    """Ensure all cps in these sequences are valid emoji cps or specific cps
+    used in forming emoji sequences.  This is a 'pre-check' that reports
+    this specific problem."""
 
-  valid_cps = set(unicode_data.get_emoji())
-  if unicode_version is None or unicode_version >= unicode_data.PROPOSED_EMOJI_AGE:
-    valid_cps |= unicode_data.proposed_emoji_cps()
-  else:
-    valid_cps = set(
-        cp for cp in valid_cps if unicode_data.age(cp) <= unicode_version)
-  valid_cps.add(0x200d)  # ZWJ
-  valid_cps.add(0x20e3)  # combining enclosing keycap
-  valid_cps.add(0xfe0f)  # variation selector (emoji presentation)
-  valid_cps.add(0xfe82b)  # PUA value for unknown flag
-  valid_cps |= TAG_SET  # used in subregion tag sequences
+    valid_cps = set(unicode_data.get_emoji())
+    if unicode_version is None or unicode_version >= unicode_data.PROPOSED_EMOJI_AGE:
+        valid_cps |= unicode_data.proposed_emoji_cps()
+    else:
+        valid_cps = set(
+            cp for cp in valid_cps if unicode_data.age(cp) <= unicode_version
+        )
+    valid_cps.add(0x200D)  # ZWJ
+    valid_cps.add(0x20E3)  # combining enclosing keycap
+    valid_cps.add(0xFE0F)  # variation selector (emoji presentation)
+    valid_cps.add(0xFE82B)  # PUA value for unknown flag
+    valid_cps |= TAG_SET  # used in subregion tag sequences
 
-  not_emoji = {}
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    for cp in seq:
-      if cp not in valid_cps:
-        if cp not in not_emoji:
-          not_emoji[cp] = []
-        not_emoji[cp].append(fp)
+    not_emoji = {}
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        for cp in seq:
+            if cp not in valid_cps:
+                if cp not in not_emoji:
+                    not_emoji[cp] = []
+                not_emoji[cp].append(fp)
 
-  if len(not_emoji):
-    print(
-        'check valid emoji cps: %d non-emoji cp found' % len(not_emoji),
-        file=sys.stderr)
-    for cp in sorted(not_emoji):
-      fps = not_emoji[cp]
-      print(
-          'check valid emoji cps: %04x (in %d sequences)' % (cp, len(fps)),
-          file=sys.stderr)
+    if len(not_emoji):
+        print(
+            "check valid emoji cps: %d non-emoji cp found" % len(not_emoji),
+            file=sys.stderr,
+        )
+        for cp in sorted(not_emoji):
+            fps = not_emoji[cp]
+            print(
+                "check valid emoji cps: %04x (in %d sequences)" % (cp, len(fps)),
+                file=sys.stderr,
+            )
 
 
 def _check_zwj(sorted_seq_to_filepath):
-  """Ensure zwj is only between two appropriate emoji.  This is a 'pre-check'
-  that reports this specific problem."""
+    """Ensure zwj is only between two appropriate emoji.  This is a 'pre-check'
+    that reports this specific problem."""
 
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    if ZWJ not in seq:
-      continue
-    if seq[0] == ZWJ:
-      print('check zwj: zwj at head of sequence in %s' % fp, file=sys.stderr)
-    if len(seq) == 1:
-      continue
-    if seq[-1] == ZWJ:
-      print('check zwj: zwj at end of sequence in %s' % fp, file=sys.stderr)
-    for i, cp in enumerate(seq):
-      if cp == ZWJ:
-        if i > 0:
-          pcp = seq[i-1]
-          if pcp != EMOJI_VS and not unicode_data.is_emoji(pcp):
-            print(
-                'check zwj: non-emoji %04x preceeds ZWJ in %s' % (pcp, fp),
-                file=sys.stderr)
-        if i < len(seq) - 1:
-          fcp = seq[i+1]
-          if not unicode_data.is_emoji(fcp):
-            print(
-                'check zwj: non-emoji %04x follows ZWJ in %s' % (fcp, fp),
-                file=sys.stderr)
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        if ZWJ not in seq:
+            continue
+        if seq[0] == ZWJ:
+            print("check zwj: zwj at head of sequence in %s" % fp, file=sys.stderr)
+        if len(seq) == 1:
+            continue
+        if seq[-1] == ZWJ:
+            print("check zwj: zwj at end of sequence in %s" % fp, file=sys.stderr)
+        for i, cp in enumerate(seq):
+            if cp == ZWJ:
+                if i > 0:
+                    pcp = seq[i - 1]
+                    if pcp != EMOJI_VS and not unicode_data.is_emoji(pcp):
+                        print(
+                            "check zwj: non-emoji %04x preceeds ZWJ in %s" % (pcp, fp),
+                            file=sys.stderr,
+                        )
+                if i < len(seq) - 1:
+                    fcp = seq[i + 1]
+                    if not unicode_data.is_emoji(fcp):
+                        print(
+                            "check zwj: non-emoji %04x follows ZWJ in %s" % (fcp, fp),
+                            file=sys.stderr,
+                        )
 
 
 def _check_flags(sorted_seq_to_filepath):
-  """Ensure regional indicators are only in sequences of one or two, and
-  never mixed."""
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    have_reg = None
-    for cp in seq:
-      is_reg = unicode_data.is_regional_indicator(cp)
-      if have_reg == None:
-        have_reg = is_reg
-      elif have_reg != is_reg:
-        print(
-            'check flags: mix of regional and non-regional in %s' % fp,
-            file=sys.stderr)
-    if have_reg and len(seq) > 2:
-      # We provide dummy glyphs for regional indicators, so there are sequences
-      # with single regional indicator symbols, the len check handles this.
-      print(
-          'check flags: regional indicator sequence length != 2 in %s' % fp,
-          file=sys.stderr)
+    """Ensure regional indicators are only in sequences of one or two, and
+    never mixed."""
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        have_reg = None
+        for cp in seq:
+            is_reg = unicode_data.is_regional_indicator(cp)
+            if have_reg == None:
+                have_reg = is_reg
+            elif have_reg != is_reg:
+                print(
+                    "check flags: mix of regional and non-regional in %s" % fp,
+                    file=sys.stderr,
+                )
+        if have_reg and len(seq) > 2:
+            # We provide dummy glyphs for regional indicators, so there are sequences
+            # with single regional indicator symbols, the len check handles this.
+            print(
+                "check flags: regional indicator sequence length != 2 in %s" % fp,
+                file=sys.stderr,
+            )
+
 
 def _check_tags(sorted_seq_to_filepath):
-  """Ensure tag sequences (for subregion flags) conform to the spec.  We don't
-  validate against CLDR, just that there's a sequence of 2 or more tags starting
-  and ending with the appropriate codepoints."""
+    """Ensure tag sequences (for subregion flags) conform to the spec.  We don't
+    validate against CLDR, just that there's a sequence of 2 or more tags starting
+    and ending with the appropriate codepoints."""
 
-  BLACK_FLAG = 0x1f3f4
-  BLACK_FLAG_SET = set([BLACK_FLAG])
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    seq_set = set(cp for cp in seq)
-    overlap_set = seq_set & TAG_SET
-    if not overlap_set:
-      continue
-    if seq[0] != BLACK_FLAG:
-      print('check tags: bad start tag in %s' % fp)
-    elif seq[-1] != END_TAG:
-      print('check tags: bad end tag in %s' % fp)
-    elif len(seq) < 4:
-      print('check tags: sequence too short in %s' % fp)
-    elif seq_set - TAG_SET != BLACK_FLAG_SET:
-      print('check tags: non-tag items in %s' % fp)
+    BLACK_FLAG = 0x1F3F4
+    BLACK_FLAG_SET = set([BLACK_FLAG])
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        seq_set = set(cp for cp in seq)
+        overlap_set = seq_set & TAG_SET
+        if not overlap_set:
+            continue
+        if seq[0] != BLACK_FLAG:
+            print("check tags: bad start tag in %s" % fp)
+        elif seq[-1] != END_TAG:
+            print("check tags: bad end tag in %s" % fp)
+        elif len(seq) < 4:
+            print("check tags: sequence too short in %s" % fp)
+        elif seq_set - TAG_SET != BLACK_FLAG_SET:
+            print("check tags: non-tag items in %s" % fp)
 
 
 def _check_skintone(sorted_seq_to_filepath):
-  """Ensure skin tone modifiers are not applied to emoji that are not defined
-  to take them.  May appear standalone, though.  Also check that emoji that take
-  skin tone modifiers have a complete set."""
-  base_to_modifiers = collections.defaultdict(set)
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    for i, cp in enumerate(seq):
-      if unicode_data.is_skintone_modifier(cp):
-        if i == 0:
-          if len(seq) > 1:
-            print(
-                'check skintone: skin color selector first in sequence %s' % fp,
-                file=sys.stderr)
-          # standalone are ok
-          continue
-        pcp = seq[i-1]
-        if not unicode_data.is_emoji_modifier_base(pcp):
-          print(
-              'check skintone: emoji skintone modifier applied to non-base ' +
-              'at %d: %s' % (i, fp), file=sys.stderr)
-        else:
-          if pcp not in base_to_modifiers:
-            base_to_modifiers[pcp] = set()
-          base_to_modifiers[pcp].add(cp)
+    """Ensure skin tone modifiers are not applied to emoji that are not defined
+    to take them.  May appear standalone, though.  Also check that emoji that take
+    skin tone modifiers have a complete set."""
+    base_to_modifiers = collections.defaultdict(set)
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        for i, cp in enumerate(seq):
+            if unicode_data.is_skintone_modifier(cp):
+                if i == 0:
+                    if len(seq) > 1:
+                        print(
+                            "check skintone: skin color selector first in sequence %s"
+                            % fp,
+                            file=sys.stderr,
+                        )
+                    # standalone are ok
+                    continue
+                pcp = seq[i - 1]
+                if not unicode_data.is_emoji_modifier_base(pcp):
+                    print(
+                        "check skintone: emoji skintone modifier applied to non-base "
+                        + "at %d: %s" % (i, fp),
+                        file=sys.stderr,
+                    )
+                else:
+                    if pcp not in base_to_modifiers:
+                        base_to_modifiers[pcp] = set()
+                    base_to_modifiers[pcp].add(cp)
 
-  for cp, modifiers in sorted(base_to_modifiers.iteritems()):
-    if len(modifiers) != 5:
-      print(
-          'check skintone: base %04x has %d modifiers defined (%s) in %s' % (
-              cp, len(modifiers),
-              ', '.join('%04x' % cp for cp in sorted(modifiers)), fp),
-          file=sys.stderr)
+    for cp, modifiers in sorted(base_to_modifiers.iteritems()):
+        if len(modifiers) != 5:
+            print(
+                "check skintone: base %04x has %d modifiers defined (%s) in %s"
+                % (
+                    cp,
+                    len(modifiers),
+                    ", ".join("%04x" % cp for cp in sorted(modifiers)),
+                    fp,
+                ),
+                file=sys.stderr,
+            )
 
 
 def _check_zwj_sequences(sorted_seq_to_filepath, unicode_version):
-  """Verify that zwj sequences are valid for the given unicode version."""
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    if ZWJ not in seq:
-      continue
-    age = unicode_data.get_emoji_sequence_age(seq)
-    if age is None or unicode_version is not None and age > unicode_version:
-      print('check zwj sequences: undefined sequence %s' % fp)
+    """Verify that zwj sequences are valid for the given unicode version."""
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        if ZWJ not in seq:
+            continue
+        age = unicode_data.get_emoji_sequence_age(seq)
+        if age is None or unicode_version is not None and age > unicode_version:
+            print("check zwj sequences: undefined sequence %s" % fp)
 
 
 def _check_no_alias_sources(sorted_seq_to_filepath):
-  """Check that we don't have sequences that we expect to be aliased to
-  some other sequence."""
-  aliases = add_aliases.read_default_emoji_aliases()
-  for seq, fp in sorted_seq_to_filepath.iteritems():
-    if seq in aliases:
-      print('check no alias sources: aliased sequence %s' % fp)
+    """Check that we don't have sequences that we expect to be aliased to
+    some other sequence."""
+    aliases = add_aliases.read_default_emoji_aliases()
+    for seq, fp in sorted_seq_to_filepath.iteritems():
+        if seq in aliases:
+            print("check no alias sources: aliased sequence %s" % fp)
 
 
 def _check_coverage(seq_to_filepath, unicode_version):
-  """Ensure we have all and only the cps and sequences that we need for the
-  font as of this version."""
+    """Ensure we have all and only the cps and sequences that we need for the
+    font as of this version."""
 
-  age = unicode_version
+    age = unicode_version
 
-  non_vs_to_canonical = {}
-  for k in seq_to_filepath:
-    if EMOJI_VS in k:
-      non_vs = unicode_data.strip_emoji_vs(k)
-      non_vs_to_canonical[non_vs] = k
+    non_vs_to_canonical = {}
+    for k in seq_to_filepath:
+        if EMOJI_VS in k:
+            non_vs = unicode_data.strip_emoji_vs(k)
+            non_vs_to_canonical[non_vs] = k
 
-  aliases = add_aliases.read_default_emoji_aliases()
-  for k, v in sorted(aliases.items()):
-    if v not in seq_to_filepath and v not in non_vs_to_canonical:
-      alias_str = unicode_data.seq_to_string(k)
-      target_str = unicode_data.seq_to_string(v)
-      print('coverage: alias %s missing target %s' % (alias_str, target_str))
-      continue
-    if k in seq_to_filepath or k in non_vs_to_canonical:
-      alias_str = unicode_data.seq_to_string(k)
-      target_str = unicode_data.seq_to_string(v)
-      print('coverage: alias %s already exists as %s (%s)' % (
-          alias_str, target_str, seq_name(v)))
-      continue
-    filename = seq_to_filepath.get(v) or seq_to_filepath[non_vs_to_canonical[v]]
-    seq_to_filepath[k] = 'alias:' + filename
+    aliases = add_aliases.read_default_emoji_aliases()
+    for k, v in sorted(aliases.items()):
+        if v not in seq_to_filepath and v not in non_vs_to_canonical:
+            alias_str = unicode_data.seq_to_string(k)
+            target_str = unicode_data.seq_to_string(v)
+            print("coverage: alias %s missing target %s" % (alias_str, target_str))
+            continue
+        if k in seq_to_filepath or k in non_vs_to_canonical:
+            alias_str = unicode_data.seq_to_string(k)
+            target_str = unicode_data.seq_to_string(v)
+            print(
+                "coverage: alias %s already exists as %s (%s)"
+                % (alias_str, target_str, seq_name(v))
+            )
+            continue
+        filename = seq_to_filepath.get(v) or seq_to_filepath[non_vs_to_canonical[v]]
+        seq_to_filepath[k] = "alias:" + filename
 
-  # check single emoji, this includes most of the special chars
-  emoji = sorted(unicode_data.get_emoji(age=age))
-  for cp in emoji:
-    if tuple([cp]) not in seq_to_filepath:
-      print(
-          'coverage: missing single %04x (%s)' % (
-              cp, unicode_data.name(cp, '<no name>')))
+    # check single emoji, this includes most of the special chars
+    emoji = sorted(unicode_data.get_emoji(age=age))
+    for cp in emoji:
+        if tuple([cp]) not in seq_to_filepath:
+            print(
+                "coverage: missing single %04x (%s)"
+                % (cp, unicode_data.name(cp, "<no name>"))
+            )
 
-  # special characters
-  # all but combining enclosing keycap are currently marked as emoji
-  for cp in [ord('*'), ord('#'), ord(u'\u20e3')] + range(0x30, 0x3a):
-    if cp not in emoji and tuple([cp]) not in seq_to_filepath:
-      print('coverage: missing special %04x (%s)' % (cp, unicode_data.name(cp)))
+    # special characters
+    # all but combining enclosing keycap are currently marked as emoji
+    for cp in [ord("*"), ord("#"), ord("\u20e3")] + range(0x30, 0x3A):
+        if cp not in emoji and tuple([cp]) not in seq_to_filepath:
+            print("coverage: missing special %04x (%s)" % (cp, unicode_data.name(cp)))
 
-  # combining sequences
-  comb_seq_to_name = sorted(
-      unicode_data.get_emoji_combining_sequences(age=age).iteritems())
-  for seq, name in comb_seq_to_name:
-    if seq not in seq_to_filepath:
-      # strip vs and try again
-      non_vs_seq = unicode_data.strip_emoji_vs(seq)
-      if non_vs_seq not in seq_to_filepath:
-        print('coverage: missing combining sequence %s (%s)' %
-              (unicode_data.seq_to_string(seq), name))
+    # combining sequences
+    comb_seq_to_name = sorted(
+        unicode_data.get_emoji_combining_sequences(age=age).iteritems()
+    )
+    for seq, name in comb_seq_to_name:
+        if seq not in seq_to_filepath:
+            # strip vs and try again
+            non_vs_seq = unicode_data.strip_emoji_vs(seq)
+            if non_vs_seq not in seq_to_filepath:
+                print(
+                    "coverage: missing combining sequence %s (%s)"
+                    % (unicode_data.seq_to_string(seq), name)
+                )
 
-  # flag sequences
-  flag_seq_to_name = sorted(
-      unicode_data.get_emoji_flag_sequences(age=age).iteritems())
-  for seq, name in flag_seq_to_name:
-    if seq not in seq_to_filepath:
-      print('coverage: missing flag sequence %s (%s)' %
-            (unicode_data.seq_to_string(seq), name))
+    # flag sequences
+    flag_seq_to_name = sorted(
+        unicode_data.get_emoji_flag_sequences(age=age).iteritems()
+    )
+    for seq, name in flag_seq_to_name:
+        if seq not in seq_to_filepath:
+            print(
+                "coverage: missing flag sequence %s (%s)"
+                % (unicode_data.seq_to_string(seq), name)
+            )
 
-  # skin tone modifier sequences
-  mod_seq_to_name = sorted(
-      unicode_data.get_emoji_modifier_sequences(age=age).iteritems())
-  for seq, name in mod_seq_to_name:
-    if seq not in seq_to_filepath:
-      print('coverage: missing modifier sequence %s (%s)' % (
-          unicode_data.seq_to_string(seq), name))
+    # skin tone modifier sequences
+    mod_seq_to_name = sorted(
+        unicode_data.get_emoji_modifier_sequences(age=age).iteritems()
+    )
+    for seq, name in mod_seq_to_name:
+        if seq not in seq_to_filepath:
+            print(
+                "coverage: missing modifier sequence %s (%s)"
+                % (unicode_data.seq_to_string(seq), name)
+            )
 
-  # zwj sequences
-  # some of ours include the emoji presentation variation selector and some
-  # don't, and the same is true for the canonical sequences.  normalize all
-  # of them to omit it to test coverage, but report the canonical sequence.
-  zwj_seq_without_vs = set()
-  for seq in seq_to_filepath:
-    if ZWJ not in seq:
-      continue
-    if EMOJI_VS in seq:
-      seq = tuple(cp for cp in seq if cp != EMOJI_VS)
-    zwj_seq_without_vs.add(seq)
+    # zwj sequences
+    # some of ours include the emoji presentation variation selector and some
+    # don't, and the same is true for the canonical sequences.  normalize all
+    # of them to omit it to test coverage, but report the canonical sequence.
+    zwj_seq_without_vs = set()
+    for seq in seq_to_filepath:
+        if ZWJ not in seq:
+            continue
+        if EMOJI_VS in seq:
+            seq = tuple(cp for cp in seq if cp != EMOJI_VS)
+        zwj_seq_without_vs.add(seq)
 
-  for seq, name in sorted(
-      unicode_data.get_emoji_zwj_sequences(age=age).iteritems()):
-    if EMOJI_VS in seq:
-      test_seq = tuple(s for s in seq if s != EMOJI_VS)
-    else:
-      test_seq = seq
-    if test_seq not in zwj_seq_without_vs:
-      print('coverage: missing (canonical) zwj sequence %s (%s)' % (
-          unicode_data.seq_to_string(seq), name))
+    for seq, name in sorted(unicode_data.get_emoji_zwj_sequences(age=age).iteritems()):
+        if EMOJI_VS in seq:
+            test_seq = tuple(s for s in seq if s != EMOJI_VS)
+        else:
+            test_seq = seq
+        if test_seq not in zwj_seq_without_vs:
+            print(
+                "coverage: missing (canonical) zwj sequence %s (%s)"
+                % (unicode_data.seq_to_string(seq), name)
+            )
 
-  # check for 'unknown flag'
-  # this is either emoji_ufe82b or 'unknown_flag', but we filter out things that
-  # don't start with our prefix so 'unknown_flag' would be excluded by default.
-  if tuple([0xfe82b]) not in seq_to_filepath:
-    print('coverage: missing unknown flag PUA fe82b')
+    # check for 'unknown flag'
+    # this is either emoji_ufe82b or 'unknown_flag', but we filter out things that
+    # don't start with our prefix so 'unknown_flag' would be excluded by default.
+    if tuple([0xFE82B]) not in seq_to_filepath:
+        print("coverage: missing unknown flag PUA fe82b")
 
 
 def check_sequence_to_filepath(seq_to_filepath, unicode_version, coverage):
-  sorted_seq_to_filepath = collections.OrderedDict(
-      sorted(seq_to_filepath.items()))
-  _check_no_vs(sorted_seq_to_filepath)
-  _check_valid_emoji_cps(sorted_seq_to_filepath, unicode_version)
-  _check_zwj(sorted_seq_to_filepath)
-  _check_flags(sorted_seq_to_filepath)
-  _check_tags(sorted_seq_to_filepath)
-  _check_skintone(sorted_seq_to_filepath)
-  _check_zwj_sequences(sorted_seq_to_filepath, unicode_version)
-  _check_no_alias_sources(sorted_seq_to_filepath)
-  if coverage:
-    _check_coverage(sorted_seq_to_filepath, unicode_version)
+    sorted_seq_to_filepath = collections.OrderedDict(sorted(seq_to_filepath.items()))
+    _check_no_vs(sorted_seq_to_filepath)
+    _check_valid_emoji_cps(sorted_seq_to_filepath, unicode_version)
+    _check_zwj(sorted_seq_to_filepath)
+    _check_flags(sorted_seq_to_filepath)
+    _check_tags(sorted_seq_to_filepath)
+    _check_skintone(sorted_seq_to_filepath)
+    _check_zwj_sequences(sorted_seq_to_filepath, unicode_version)
+    _check_no_alias_sources(sorted_seq_to_filepath)
+    if coverage:
+        _check_coverage(sorted_seq_to_filepath, unicode_version)
 
 
 def create_sequence_to_filepath(name_to_dirpath, prefix, suffix):
-  """Check names, and convert name to sequences for names that are ok,
-  returning a sequence to file path mapping.  Reports bad segments
-  of a name to stderr."""
-  segment_re = re.compile(r'^[0-9a-f]{4,6}$')
-  result = {}
-  for name, dirname in name_to_dirpath.iteritems():
-    if not name.startswith(prefix):
-      print('expected prefix "%s" for "%s"' % (prefix, name))
-      continue
+    """Check names, and convert name to sequences for names that are ok,
+    returning a sequence to file path mapping.  Reports bad segments
+    of a name to stderr."""
+    segment_re = re.compile(r"^[0-9a-f]{4,6}$")
+    result = {}
+    for name, dirname in name_to_dirpath.iteritems():
+        if not name.startswith(prefix):
+            print('expected prefix "%s" for "%s"' % (prefix, name))
+            continue
 
-    segments = name[len(prefix): -len(suffix)].split('_')
-    segfail = False
-    seq = []
-    for s in segments:
-      if not segment_re.match(s):
-        print('bad codepoint name "%s" in %s/%s' % (s, dirname, name))
-        segfail = True
-        continue
-      n = int(s, 16)
-      if n > 0x10ffff:
-        print('codepoint "%s" out of range in %s/%s' % (s, dirname, name))
-        segfail = True
-        continue
-      seq.append(n)
-    if not segfail:
-      result[tuple(seq)] = path.join(dirname, name)
-  return result
+        segments = name[len(prefix) : -len(suffix)].split("_")
+        segfail = False
+        seq = []
+        for s in segments:
+            if not segment_re.match(s):
+                print('bad codepoint name "%s" in %s/%s' % (s, dirname, name))
+                segfail = True
+                continue
+            n = int(s, 16)
+            if n > 0x10FFFF:
+                print('codepoint "%s" out of range in %s/%s' % (s, dirname, name))
+                segfail = True
+                continue
+            seq.append(n)
+        if not segfail:
+            result[tuple(seq)] = path.join(dirname, name)
+    return result
 
 
 def collect_name_to_dirpath(directory, prefix, suffix, exclude=None):
-  """Return a mapping from filename to path rooted at directory, ignoring files
-  that don't match suffix, and subtrees with names in exclude.  Report when a
-  filename appears in more than one subdir; the first path found is kept."""
-  result = {}
-  for dirname, dirs, files in os.walk(directory, topdown=True):
-    if exclude:
-      dirs[:] = [d for d in dirs if d not in exclude]
+    """Return a mapping from filename to path rooted at directory, ignoring files
+    that don't match suffix, and subtrees with names in exclude.  Report when a
+    filename appears in more than one subdir; the first path found is kept."""
+    result = {}
+    for dirname, dirs, files in os.walk(directory, topdown=True):
+        if exclude:
+            dirs[:] = [d for d in dirs if d not in exclude]
 
-    if directory != '.':
-      dirname = path.join(directory, dirname)
-    for f in files:
-      if not f.endswith(suffix):
-        continue
-      if f in result:
-        print('duplicate file "%s" in %s and %s ' % (
-            f, dirname, result[f]), file=sys.stderr)
-        continue
-      result[f] = dirname
-  return result
+        if directory != ".":
+            dirname = path.join(directory, dirname)
+        for f in files:
+            if not f.endswith(suffix):
+                continue
+            if f in result:
+                print(
+                    'duplicate file "%s" in %s and %s ' % (f, dirname, result[f]),
+                    file=sys.stderr,
+                )
+                continue
+            result[f] = dirname
+    return result
 
 
 def collect_name_to_dirpath_with_override(dirs, prefix, suffix, exclude=None):
-  """Return a mapping from filename to a directory path rooted at a directory
-  in dirs, using collect_name_to_filepath.  The last directory is retained. This
-  does not report an error if a file appears under more than one root directory,
-  so lets later root directories override earlier ones.  Use 'exclude' to
-  name subdirectories (of any root) whose subtree you wish to skip."""
-  result = {}
-  for d in dirs:
-    result.update(collect_name_to_dirpath(d, prefix, suffix, exclude))
-  return result
+    """Return a mapping from filename to a directory path rooted at a directory
+    in dirs, using collect_name_to_filepath.  The last directory is retained. This
+    does not report an error if a file appears under more than one root directory,
+    so lets later root directories override earlier ones.  Use 'exclude' to
+    name subdirectories (of any root) whose subtree you wish to skip."""
+    result = {}
+    for d in dirs:
+        result.update(collect_name_to_dirpath(d, prefix, suffix, exclude))
+    return result
 
 
 def run_check(dirs, prefix, suffix, exclude, unicode_version, coverage):
-  msg = ''
-  if unicode_version:
-    msg = ' (%3.1f)' % unicode_version
-  print('Checking files with prefix "%s" and suffix "%s"%s in:\n  %s' % (
-      prefix, suffix, msg, '\n  '.join(dirs)))
-  name_to_dirpath = collect_name_to_dirpath_with_override(
-      dirs, prefix=prefix, suffix=suffix, exclude=exclude)
-  print('checking %d names' % len(name_to_dirpath))
-  seq_to_filepath = create_sequence_to_filepath(name_to_dirpath, prefix, suffix)
-  print('checking %d sequences' % len(seq_to_filepath))
-  check_sequence_to_filepath(seq_to_filepath, unicode_version, coverage)
-  print('done.')
+    msg = ""
+    if unicode_version:
+        msg = " (%3.1f)" % unicode_version
+    print(
+        'Checking files with prefix "%s" and suffix "%s"%s in:\n  %s'
+        % (prefix, suffix, msg, "\n  ".join(dirs))
+    )
+    name_to_dirpath = collect_name_to_dirpath_with_override(
+        dirs, prefix=prefix, suffix=suffix, exclude=exclude
+    )
+    print("checking %d names" % len(name_to_dirpath))
+    seq_to_filepath = create_sequence_to_filepath(name_to_dirpath, prefix, suffix)
+    print("checking %d sequences" % len(seq_to_filepath))
+    check_sequence_to_filepath(seq_to_filepath, unicode_version, coverage)
+    print("done.")
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-d', '--dirs', help='directory roots containing emoji images',
-      metavar='dir', nargs='+', required=True)
-  parser.add_argument(
-      '-e', '--exclude', help='names of source subdirs to exclude',
-      metavar='dir', nargs='+')
-  parser.add_argument(
-      '-c', '--coverage', help='test for complete coverage',
-      action='store_true')
-  parser.add_argument(
-      '-p', '--prefix', help='prefix to match, default "emoji_u"',
-      metavar='pfx', default='emoji_u')
-  parser.add_argument(
-      '-s', '--suffix', help='suffix to match, default ".png"', metavar='sfx',
-      default='.png')
-  parser.add_argument(
-      '-u', '--unicode_version', help='limit to this unicode version or before',
-      metavar='version', type=float)
-  args = parser.parse_args()
-  run_check(
-      args.dirs, args.prefix, args.suffix, args.exclude, args.unicode_version,
-      args.coverage)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--dirs",
+        help="directory roots containing emoji images",
+        metavar="dir",
+        nargs="+",
+        required=True,
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude",
+        help="names of source subdirs to exclude",
+        metavar="dir",
+        nargs="+",
+    )
+    parser.add_argument(
+        "-c", "--coverage", help="test for complete coverage", action="store_true"
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        help='prefix to match, default "emoji_u"',
+        metavar="pfx",
+        default="emoji_u",
+    )
+    parser.add_argument(
+        "-s",
+        "--suffix",
+        help='suffix to match, default ".png"',
+        metavar="sfx",
+        default=".png",
+    )
+    parser.add_argument(
+        "-u",
+        "--unicode_version",
+        help="limit to this unicode version or before",
+        metavar="version",
+        type=float,
+    )
+    args = parser.parse_args()
+    run_check(
+        args.dirs,
+        args.prefix,
+        args.suffix,
+        args.exclude,
+        args.unicode_version,
+        args.coverage,
+    )
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/collect_emoji_svg.py
+++ b/collect_emoji_svg.py
@@ -42,109 +42,127 @@ import sys
 
 from nototools import tool_utils
 
+
 def _is_svg(f):
-  return f.endswith('.svg')
+    return f.endswith(".svg")
 
 
 def _is_svg_and_startswith_emoji(f):
-  return f.endswith('.svg') and f.startswith('emoji_u')
+    return f.endswith(".svg") and f.startswith("emoji_u")
 
 
 def _flag_rename(f):
-  """Converts a file name from two-letter upper-case ASCII to our expected
-  'emoji_uXXXXX_XXXXX form, mapping each character to the corresponding
-  regional indicator symbol."""
+    """Converts a file name from two-letter upper-case ASCII to our expected
+    'emoji_uXXXXX_XXXXX form, mapping each character to the corresponding
+    regional indicator symbol."""
 
-  cp_strs = []
-  name, ext = os.path.splitext(f)
-  if len(name) != 2:
-    raise ValueError('illegal flag name "%s"' % f)
-  for cp in name:
-    if not ('A' <= cp <= 'Z'):
-      raise ValueError('illegal flag name "%s"' % f)
-    ncp = 0x1f1e6 - 0x41 + ord(cp)
-    cp_strs.append("%04x" % ncp)
-  return 'emoji_u%s%s' % ('_'.join(cp_strs), ext)
+    cp_strs = []
+    name, ext = os.path.splitext(f)
+    if len(name) != 2:
+        raise ValueError('illegal flag name "%s"' % f)
+    for cp in name:
+        if not ("A" <= cp <= "Z"):
+            raise ValueError('illegal flag name "%s"' % f)
+        ncp = 0x1F1E6 - 0x41 + ord(cp)
+        cp_strs.append("%04x" % ncp)
+    return "emoji_u%s%s" % ("_".join(cp_strs), ext)
 
 
 def copy_with_rename(src_dir, dst_dir, accept_pred=None, rename=None):
-  """Copy files from src_dir to dst_dir that match accept_pred (all if None) and
-  rename using rename (if not None), replacing existing files.  accept_pred
-  takes the filename and returns True if the file should be copied, rename takes
-  the filename and returns a new file name."""
+    """Copy files from src_dir to dst_dir that match accept_pred (all if None) and
+    rename using rename (if not None), replacing existing files.  accept_pred
+    takes the filename and returns True if the file should be copied, rename takes
+    the filename and returns a new file name."""
 
-  count = 0
-  replace_count = 0
-  for src_filename in os.listdir(src_dir):
-    if accept_pred and not accept_pred(src_filename):
-      continue
-    dst_filename = rename(src_filename) if rename else src_filename
-    src = os.path.join(src_dir, src_filename)
-    dst = os.path.join(dst_dir, dst_filename)
-    if os.path.exists(dst):
-      logging.debug('Replacing existing file %s', dst)
-      os.unlink(dst)
-      replace_count += 1
-    shutil.copy2(src, dst)
-    logging.debug('cp -p %s %s', src, dst)
-    count += 1
-  if logging.getLogger().getEffectiveLevel() <= logging.INFO:
-    src_short = tool_utils.short_path(src_dir)
-    dst_short = tool_utils.short_path(dst_dir)
-    logging.info('Copied %d files (replacing %d) from %s to %s',
-        count, replace_count, src_short, dst_short)
+    count = 0
+    replace_count = 0
+    for src_filename in os.listdir(src_dir):
+        if accept_pred and not accept_pred(src_filename):
+            continue
+        dst_filename = rename(src_filename) if rename else src_filename
+        src = os.path.join(src_dir, src_filename)
+        dst = os.path.join(dst_dir, dst_filename)
+        if os.path.exists(dst):
+            logging.debug("Replacing existing file %s", dst)
+            os.unlink(dst)
+            replace_count += 1
+        shutil.copy2(src, dst)
+        logging.debug("cp -p %s %s", src, dst)
+        count += 1
+    if logging.getLogger().getEffectiveLevel() <= logging.INFO:
+        src_short = tool_utils.short_path(src_dir)
+        dst_short = tool_utils.short_path(dst_dir)
+        logging.info(
+            "Copied %d files (replacing %d) from %s to %s",
+            count,
+            replace_count,
+            src_short,
+            dst_short,
+        )
 
 
-def build_svg_dir(dst_dir, clean=False, emoji_dir='', flags_dir=''):
-  """Copies/renames files from emoji_dir and then flags_dir, giving them the
-  standard format and prefix ('emoji_u' followed by codepoints expressed in hex
-  separated by underscore).  If clean, removes the target dir before proceding.
-  If either emoji_dir or flags_dir are empty, skips them."""
+def build_svg_dir(dst_dir, clean=False, emoji_dir="", flags_dir=""):
+    """Copies/renames files from emoji_dir and then flags_dir, giving them the
+    standard format and prefix ('emoji_u' followed by codepoints expressed in hex
+    separated by underscore).  If clean, removes the target dir before proceding.
+    If either emoji_dir or flags_dir are empty, skips them."""
 
-  dst_dir = tool_utils.ensure_dir_exists(dst_dir, clean=clean)
+    dst_dir = tool_utils.ensure_dir_exists(dst_dir, clean=clean)
 
-  if not emoji_dir and not flags_dir:
-    logging.warning('Nothing to do.')
-    return
+    if not emoji_dir and not flags_dir:
+        logging.warning("Nothing to do.")
+        return
 
-  if emoji_dir:
-    copy_with_rename(
-        emoji_dir, dst_dir, accept_pred=_is_svg_and_startswith_emoji)
+    if emoji_dir:
+        copy_with_rename(emoji_dir, dst_dir, accept_pred=_is_svg_and_startswith_emoji)
 
-  if flags_dir:
-     copy_with_rename(
-        flags_dir, dst_dir, accept_pred=_is_svg, rename=_flag_rename)
+    if flags_dir:
+        copy_with_rename(flags_dir, dst_dir, accept_pred=_is_svg, rename=_flag_rename)
 
 
 def main(argv):
-  DEFAULT_EMOJI_DIR = '[emoji]/svg'
-  DEFAULT_FLAGS_DIR = '[emoji]/third_party/region-flags/svg'
+    DEFAULT_EMOJI_DIR = "[emoji]/svg"
+    DEFAULT_FLAGS_DIR = "[emoji]/third_party/region-flags/svg"
 
-  parser = argparse.ArgumentParser(
-      description='Collect svg files into target directory with prefix.')
-  parser.add_argument(
-      'dst_dir', help='Directory to hold copied files.', metavar='dir')
-  parser.add_argument(
-      '--clean', '-c', help='Replace target directory', action='store_true')
-  parser.add_argument(
-      '--flags_dir', '-f', metavar='dir', help='directory containing flag svg, '
-      'default %s' % DEFAULT_FLAGS_DIR, default=DEFAULT_FLAGS_DIR)
-  parser.add_argument(
-      '--emoji_dir', '-e', metavar='dir',
-      help='directory containing emoji svg, default %s' % DEFAULT_EMOJI_DIR,
-      default=DEFAULT_EMOJI_DIR)
-  parser.add_argument(
-      '-l', '--loglevel', help='log level name/value', default='warning')
-  args = parser.parse_args(argv)
+    parser = argparse.ArgumentParser(
+        description="Collect svg files into target directory with prefix."
+    )
+    parser.add_argument(
+        "dst_dir", help="Directory to hold copied files.", metavar="dir"
+    )
+    parser.add_argument(
+        "--clean", "-c", help="Replace target directory", action="store_true"
+    )
+    parser.add_argument(
+        "--flags_dir",
+        "-f",
+        metavar="dir",
+        help="directory containing flag svg, default %s" % DEFAULT_FLAGS_DIR,
+        default=DEFAULT_FLAGS_DIR,
+    )
+    parser.add_argument(
+        "--emoji_dir",
+        "-e",
+        metavar="dir",
+        help="directory containing emoji svg, default %s" % DEFAULT_EMOJI_DIR,
+        default=DEFAULT_EMOJI_DIR,
+    )
+    parser.add_argument(
+        "-l", "--loglevel", help="log level name/value", default="warning"
+    )
+    args = parser.parse_args(argv)
 
-  tool_utils.setup_logging(args.loglevel)
+    tool_utils.setup_logging(args.loglevel)
 
-  args.flags_dir = tool_utils.resolve_path(args.flags_dir)
-  args.emoji_dir = tool_utils.resolve_path(args.emoji_dir)
-  build_svg_dir(
-      args.dst_dir, clean=args.clean, emoji_dir=args.emoji_dir,
-      flags_dir=args.flags_dir)
+    args.flags_dir = tool_utils.resolve_path(args.flags_dir)
+    args.emoji_dir = tool_utils.resolve_path(args.emoji_dir)
+    build_svg_dir(
+        args.dst_dir,
+        clean=args.clean,
+        emoji_dir=args.emoji_dir,
+        flags_dir=args.flags_dir,
+    )
 
 
-if __name__ == '__main__':
-  main(sys.argv[1:])
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/flag_glyph_name.py
+++ b/flag_glyph_name.py
@@ -15,42 +15,47 @@
 # limitations under the License.
 
 """Generate a glyph name for flag emojis."""
+
 from __future__ import print_function
 
-__author__ = 'roozbeh@google.com (Roozbeh Pournader)'
+__author__ = "roozbeh@google.com (Roozbeh Pournader)"
 
 import re
 import sys
 
 import add_emoji_gsub
 
+
 def two_letter_code_to_glyph_name(region_code):
-    return 'u%04x_%04x' % (
+    return "u%04x_%04x" % (
         add_emoji_gsub.reg_indicator(region_code[0]),
-        add_emoji_gsub.reg_indicator(region_code[1]))
+        add_emoji_gsub.reg_indicator(region_code[1]),
+    )
 
 
-subcode_re = re.compile(r'[0-9a-z]{2}-[0-9a-z]+$')
+subcode_re = re.compile(r"[0-9a-z]{2}-[0-9a-z]+$")
+
+
 def hyphenated_code_to_glyph_name(sub_code):
-  # Hyphenated codes use tag sequences, not regional indicator symbol pairs.
-  sub_code = sub_code.lower()
-  if not subcode_re.match(sub_code):
-    raise Exception('%s is not a valid flag subcode' % sub_code)
-  cps = ['u1f3f4']
-  cps.extend('e00%02x' % ord(cp) for cp in sub_code if cp != '-')
-  cps.append('e007f')
-  return '_'.join(cps)
+    # Hyphenated codes use tag sequences, not regional indicator symbol pairs.
+    sub_code = sub_code.lower()
+    if not subcode_re.match(sub_code):
+        raise Exception("%s is not a valid flag subcode" % sub_code)
+    cps = ["u1f3f4"]
+    cps.extend("e00%02x" % ord(cp) for cp in sub_code if cp != "-")
+    cps.append("e007f")
+    return "_".join(cps)
 
 
 def flag_code_to_glyph_name(flag_code):
-  if '-' in flag_code:
-    return hyphenated_code_to_glyph_name(flag_code)
-  return two_letter_code_to_glyph_name(flag_code)
+    if "-" in flag_code:
+        return hyphenated_code_to_glyph_name(flag_code)
+    return two_letter_code_to_glyph_name(flag_code)
 
 
 def main():
-    print(' '.join([
-        flag_code_to_glyph_name(flag_code) for flag_code in sys.argv[1:]]))
+    print(" ".join([flag_code_to_glyph_name(flag_code) for flag_code in sys.argv[1:]]))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/flag_info.py
+++ b/flag_info.py
@@ -17,6 +17,7 @@
 """Quick tool to display count/ids of flag images in a directory named
 either using ASCII upper case pairs or the emoji_u+codepoint_sequence
 names."""
+
 from __future__ import print_function
 
 import argparse
@@ -25,61 +26,68 @@ import glob
 import os
 from os import path
 
+
 def _flag_names_from_emoji_file_names(src):
-  def _flag_char(char_str):
-    return unichr(ord('A') + int(char_str, 16) - 0x1f1e6)
-  flag_re = re.compile('emoji_u(1f1[0-9a-f]{2})_(1f1[0-9a-f]{2}).png')
-  flags = set()
-  for f in glob.glob(path.join(src, 'emoji_u*.png')):
-    m = flag_re.match(path.basename(f))
-    if not m:
-      continue
-    flag_short_name = _flag_char(m.group(1)) + _flag_char(m.group(2))
-    flags.add(flag_short_name)
-  return flags
+    def _flag_char(char_str):
+        return unichr(ord("A") + int(char_str, 16) - 0x1F1E6)
+
+    flag_re = re.compile("emoji_u(1f1[0-9a-f]{2})_(1f1[0-9a-f]{2}).png")
+    flags = set()
+    for f in glob.glob(path.join(src, "emoji_u*.png")):
+        m = flag_re.match(path.basename(f))
+        if not m:
+            continue
+        flag_short_name = _flag_char(m.group(1)) + _flag_char(m.group(2))
+        flags.add(flag_short_name)
+    return flags
 
 
 def _flag_names_from_file_names(src):
-  flag_re = re.compile('([A-Z]{2}).png')
-  flags = set()
-  for f in glob.glob(path.join(src, '*.png')):
-    m = flag_re.match(path.basename(f))
-    if not m:
-      print('no match')
-      continue
-    flags.add(m.group(1))
-  return flags
+    flag_re = re.compile("([A-Z]{2}).png")
+    flags = set()
+    for f in glob.glob(path.join(src, "*.png")):
+        m = flag_re.match(path.basename(f))
+        if not m:
+            print("no match")
+            continue
+        flags.add(m.group(1))
+    return flags
 
 
 def _dump_flag_info(names):
-  prev = None
-  print('%d flags' % len(names))
-  for n in sorted(names):
-    if n[0] != prev:
-      if prev:
-        print()
-      prev = n[0]
-    print(n, end=' ')
-  print()
+    prev = None
+    print("%d flags" % len(names))
+    for n in sorted(names):
+        if n[0] != prev:
+            if prev:
+                print()
+            prev = n[0]
+        print(n, end=" ")
+    print()
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-s', '--srcdir', help='location of files', metavar='dir',
-      required=True)
-  parser.add_argument(
-      '-n', '--name_type', help='type of names', metavar='type',
-      choices=['ascii', 'codepoint'], required=True)
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-s", "--srcdir", help="location of files", metavar="dir", required=True
+    )
+    parser.add_argument(
+        "-n",
+        "--name_type",
+        help="type of names",
+        metavar="type",
+        choices=["ascii", "codepoint"],
+        required=True,
+    )
+    args = parser.parse_args()
 
-  if args.name_type == 'ascii':
-    names = _flag_names_from_file_names(args.srcdir)
-  else:
-    names = _flag_names_from_emoji_file_names(args.srcdir)
-  print(args.srcdir)
-  _dump_flag_info(names)
+    if args.name_type == "ascii":
+        names = _flag_names_from_file_names(args.srcdir)
+    else:
+        names = _flag_names_from_emoji_file_names(args.srcdir)
+    print(args.srcdir)
+    _dump_flag_info(names)
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739829690,
+        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,108 @@
+{
+  description = "flake for apple-emoji-linux";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      treefmt-nix,
+    }:
+    let
+      forAllSystems =
+        function:
+        nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed (
+          system: function nixpkgs.legacyPackages.${system}
+        );
+
+      treefmtConfig = forAllSystems (
+        pkgs:
+        treefmt-nix.lib.evalModule pkgs {
+          projectRootFile = "flake.nix";
+          programs = {
+            nixfmt.enable = true;
+            yamlfmt.enable = true;
+            ruff-format.enable = true;
+            mdformat.enable = true;
+          };
+          settings.excludes = [
+            "*.gitignore"
+            "*.lock"
+            "*.png"
+            "*.pyc"
+            "*.txt"
+            "*.ttx*"
+            "AUTHORS"
+            "CONTRIBUTORS"
+            "Makefile"
+            "LICENSE"
+            "third_party/*"
+          ];
+        }
+      );
+
+      buildFromSource =
+        {
+          stdenv,
+          python3,
+          optipng,
+          zopfli,
+          pngquant,
+          imagemagick,
+          which,
+        }:
+
+        stdenv.mkDerivation {
+          pname = "apple-emoji-linux";
+          version = "17.4";
+
+          src = ./.;
+
+          enableParallelBuilding = true;
+
+          nativeBuildInputs = [
+            which
+            (python3.withPackages (
+              python-pkgs: with python-pkgs; [
+                fonttools
+                nototools
+              ]
+            ))
+            optipng
+            zopfli
+            pngquant
+            imagemagick
+          ];
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/share/fonts/truetype
+            cp ./AppleColorEmoji.ttf $out/share/fonts/truetype
+            runHook postInstall
+          '';
+        };
+    in
+    {
+      # run `nix fmt` to format all code
+      formatter = forAllSystems (pkgs: treefmtConfig.${pkgs.system}.config.build.wrapper);
+
+      # run `nix flake check` to ensure code is formatted
+      checks = forAllSystems (pkgs: {
+        formatting = treefmtConfig.${pkgs.system}.config.build.check self;
+      });
+
+      # run `nix develop` to get dropped into a shell with all the dependencies
+      # and `nix build` to build from source
+      packages = forAllSystems (pkgs: rec {
+        apple-emoji-linux = pkgs.callPackage buildFromSource { };
+        default = apple-emoji-linux;
+      });
+    };
+}

--- a/gen_version.py
+++ b/gen_version.py
@@ -52,141 +52,157 @@ from nototools import tool_utils
 # emoji template ttx file which matches these.  Why then require the
 # input argument, you ask?  Um... testing?
 _nameid_re = re.compile(r'\s*<namerecord nameID="5"')
-_version_re = re.compile(r'\s*Version\s(\d+.\d{2,3})')
+_version_re = re.compile(r"\s*Version\s(\d+.\d{2,3})")
 _headrev_re = re.compile(r'\s*<fontRevision value="(\d+.\d{2,3})"/>')
 
+
 def _get_existing_version(lines):
-  """Scan lines for all existing version numbers, and ensure they match.
-  Return the matched version number string."""
+    """Scan lines for all existing version numbers, and ensure they match.
+    Return the matched version number string."""
 
-  version = None
-  def check_version(new_version):
-    if version is not None and new_version != version:
-      raise Exception(
-          'version %s and namerecord version %s do not match' % (
-              version, new_version))
-    return new_version
+    version = None
 
-  saw_nameid = False
-  for line in lines:
-    if saw_nameid:
-      saw_nameid = False
-      m = _version_re.match(line)
-      if not m:
-        raise Exception('could not match line "%s" in namerecord' % line)
-      version = check_version(m.group(1))
-    elif _nameid_re.match(line):
-      saw_nameid = True
-    else:
-      m = _headrev_re.match(line)
-      if m:
-        version = check_version(m.group(1))
-  return version
+    def check_version(new_version):
+        if version is not None and new_version != version:
+            raise Exception(
+                "version %s and namerecord version %s do not match"
+                % (version, new_version)
+            )
+        return new_version
+
+    saw_nameid = False
+    for line in lines:
+        if saw_nameid:
+            saw_nameid = False
+            m = _version_re.match(line)
+            if not m:
+                raise Exception('could not match line "%s" in namerecord' % line)
+            version = check_version(m.group(1))
+        elif _nameid_re.match(line):
+            saw_nameid = True
+        else:
+            m = _headrev_re.match(line)
+            if m:
+                version = check_version(m.group(1))
+    return version
 
 
 def _version_to_mm(version):
-  majs, mins = version.split('.')
-  minor_len = len(mins)
-  return int(majs), int(mins), minor_len
+    majs, mins = version.split(".")
+    minor_len = len(mins)
+    return int(majs), int(mins), minor_len
 
 
 def _mm_to_version(major, minor, minor_len):
-  fmt = '%%d.%%0%dd' % minor_len
-  return fmt % (major, minor)
+    fmt = "%%d.%%0%dd" % minor_len
+    return fmt % (major, minor)
 
 
 def _version_compare(lhs, rhs):
-  lmaj, lmin, llen = _version_to_mm(lhs)
-  rmaj, rmin, rlen = _version_to_mm(rhs)
-  # if major versions differ, we don't care about the minor length, else
-  # they should be the same
-  if lmaj != rmaj:
-    return lmaj - rmaj
-  if llen != rlen:
-    raise Exception('minor version lengths differ: "%s" and "%s"' % (lhs, rhs))
-  return lmin - rmin
+    lmaj, lmin, llen = _version_to_mm(lhs)
+    rmaj, rmin, rlen = _version_to_mm(rhs)
+    # if major versions differ, we don't care about the minor length, else
+    # they should be the same
+    if lmaj != rmaj:
+        return lmaj - rmaj
+    if llen != rlen:
+        raise Exception('minor version lengths differ: "%s" and "%s"' % (lhs, rhs))
+    return lmin - rmin
 
 
 def _version_bump(version):
-  major, minor, minor_len = _version_to_mm(version)
-  minor = (minor + 1) % (10 ** minor_len)
-  if minor == 0:
-    raise Exception('cannot bump version "%s", requires new major' % version)
-  return _mm_to_version(major, minor, minor_len)
+    major, minor, minor_len = _version_to_mm(version)
+    minor = (minor + 1) % (10**minor_len)
+    if minor == 0:
+        raise Exception('cannot bump version "%s", requires new major' % version)
+    return _mm_to_version(major, minor, minor_len)
 
 
 def _get_repo_version_str(beta):
-  """See above for description of this string."""
-  if beta is not None:
-    date_str = datetime.date.today().strftime('%Y%m%d')
-    return 'GOOG;noto-emoji:%s;BETA %s' % (date_str, beta)
+    """See above for description of this string."""
+    if beta is not None:
+        date_str = datetime.date.today().strftime("%Y%m%d")
+        return "GOOG;noto-emoji:%s;BETA %s" % (date_str, beta)
 
-  p = tool_utils.resolve_path('[emoji]')
-  commit, date, _ = tool_utils.git_head_commit(p)
-  if not tool_utils.git_check_remote_commit(p, commit):
-    raise Exception('emoji not on upstream master branch')
-  date_re = re.compile(r'(\d{4})-(\d{2})-(\d{2})')
-  m = date_re.match(date)
-  if not m:
-    raise Exception('could not match "%s" with "%s"' % (date, date_re.pattern))
-  ymd = ''.join(m.groups())
-  return 'GOOG;noto-emoji:%s:%s' % (ymd, commit[:12])
+    p = tool_utils.resolve_path("[emoji]")
+    commit, date, _ = tool_utils.git_head_commit(p)
+    if not tool_utils.git_check_remote_commit(p, commit):
+        raise Exception("emoji not on upstream master branch")
+    date_re = re.compile(r"(\d{4})-(\d{2})-(\d{2})")
+    m = date_re.match(date)
+    if not m:
+        raise Exception('could not match "%s" with "%s"' % (date, date_re.pattern))
+    ymd = "".join(m.groups())
+    return "GOOG;noto-emoji:%s:%s" % (ymd, commit[:12])
 
 
 def _replace_existing_version(lines, version, version_str):
-  """Update lines with new version strings in appropriate places."""
-  saw_nameid = False
-  for i in range(len(lines)):
-    line = lines[i]
-    if saw_nameid:
-      saw_nameid = False
-      # preserve indentation
-      lead_ws = len(line) - len(line.lstrip())
-      lines[i] = line[:lead_ws] + version_str + '\n'
-    elif _nameid_re.match(line):
-      saw_nameid = True
-    elif _headrev_re.match(line):
-      lead_ws = len(line) - len(line.lstrip())
-      lines[i] = line[:lead_ws] + '<fontRevision value="%s"/>\n' % version
+    """Update lines with new version strings in appropriate places."""
+    saw_nameid = False
+    for i in range(len(lines)):
+        line = lines[i]
+        if saw_nameid:
+            saw_nameid = False
+            # preserve indentation
+            lead_ws = len(line) - len(line.lstrip())
+            lines[i] = line[:lead_ws] + version_str + "\n"
+        elif _nameid_re.match(line):
+            saw_nameid = True
+        elif _headrev_re.match(line):
+            lead_ws = len(line) - len(line.lstrip())
+            lines[i] = line[:lead_ws] + '<fontRevision value="%s"/>\n' % version
 
 
 def update_version(srcfile, dstfile, version, beta):
-  """Update version in srcfile and write to dstfile.  If version is None,
-  bumps the current version, else version must be greater than the
-  current verison."""
+    """Update version in srcfile and write to dstfile.  If version is None,
+    bumps the current version, else version must be greater than the
+    current verison."""
 
-  with open(srcfile, 'r') as f:
-    lines = f.readlines()
-  current_version = _get_existing_version(lines)
-  if not version:
-    version = _version_bump(current_version)
-  elif version and _version_compare(version, current_version) <= 0:
-    raise Exception('new version %s is <= current version %s' % (
-        version, current_version))
-  version_str = 'Version %s;%s' % (version, _get_repo_version_str(beta))
-  _replace_existing_version(lines, version, version_str)
-  with open(dstfile, 'w') as f:
-    for line in lines:
-      f.write(line)
+    with open(srcfile, "r") as f:
+        lines = f.readlines()
+    current_version = _get_existing_version(lines)
+    if not version:
+        version = _version_bump(current_version)
+    elif version and _version_compare(version, current_version) <= 0:
+        raise Exception(
+            "new version %s is <= current version %s" % (version, current_version)
+        )
+    version_str = "Version %s;%s" % (version, _get_repo_version_str(beta))
+    _replace_existing_version(lines, version, version_str)
+    with open(dstfile, "w") as f:
+        for line in lines:
+            f.write(line)
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-v', '--version', help='version number, default bumps the current '
-      'version', metavar='ver')
-  parser.add_argument(
-      '-s', '--src', help='ttx file with name and head tables',
-      metavar='file', required=True)
-  parser.add_argument(
-      '-d', '--dst', help='name of edited ttx file to write',
-      metavar='file', required=True)
-  parser.add_argument(
-      '-b', '--beta', help='beta tag if font is built using external resources')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="version number, default bumps the current version",
+        metavar="ver",
+    )
+    parser.add_argument(
+        "-s",
+        "--src",
+        help="ttx file with name and head tables",
+        metavar="file",
+        required=True,
+    )
+    parser.add_argument(
+        "-d",
+        "--dst",
+        help="name of edited ttx file to write",
+        metavar="file",
+        required=True,
+    )
+    parser.add_argument(
+        "-b", "--beta", help="beta tag if font is built using external resources"
+    )
+    args = parser.parse_args()
 
-  update_version(args.src, args.dst, args.version, args.beta)
+    update_version(args.src, args.dst, args.version, args.beta)
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/generate_emoji_html.py
+++ b/generate_emoji_html.py
@@ -19,6 +19,7 @@
 This takes a list of directories containing emoji image files, and
 builds an html page presenting the images along with their composition
 (for sequences) and unicode names (for individual emoji)."""
+
 from __future__ import print_function
 
 import argparse
@@ -38,422 +39,435 @@ from nototools import unicode_data
 
 import add_aliases
 
-_default_dir = 'png/128'
-_default_ext = 'png'
-_default_prefix = 'emoji_u'
-_default_title = 'Emoji List'
+_default_dir = "png/128"
+_default_ext = "png"
+_default_prefix = "emoji_u"
+_default_title = "Emoji List"
 
 # DirInfo represents information about a directory of file names.
 # - directory is the directory path
 # - title is the title to use for this directory
 # - filemap is a dict mapping from a tuple of codepoints to the name of
 #   a file in the directory.
-DirInfo = collections.namedtuple('DirInfo', 'directory, title, filemap')
+DirInfo = collections.namedtuple("DirInfo", "directory, title, filemap")
 
 
 def _merge_keys(dicts):
-  """Return the union of the keys in the list of dicts."""
-  keys = []
-  for d in dicts:
-    keys.extend(d.keys())
-  return frozenset(keys)
+    """Return the union of the keys in the list of dicts."""
+    keys = []
+    for d in dicts:
+        keys.extend(d.keys())
+    return frozenset(keys)
 
 
-def _generate_row_cells(
-    key, font, aliases, excluded, dir_infos, basepaths, colors):
-  CELL_PREFIX = '<td>'
-  indices = range(len(basepaths))
-  def _cell(info, basepath):
-    if key in info.filemap:
-      return '<img src="%s">' % path.join(basepath, info.filemap[key])
-    if key in aliases:
-      return 'alias'
-    if key in excluded:
-      return 'exclude'
-    return 'missing'
+def _generate_row_cells(key, font, aliases, excluded, dir_infos, basepaths, colors):
+    CELL_PREFIX = "<td>"
+    indices = range(len(basepaths))
 
-  def _text_cell(text_dir):
-    text = ''.join(unichr(cp) for cp in key)
-    return '<span class="efont" dir="%s">%s</span>' % (text_dir, text)
+    def _cell(info, basepath):
+        if key in info.filemap:
+            return '<img src="%s">' % path.join(basepath, info.filemap[key])
+        if key in aliases:
+            return "alias"
+        if key in excluded:
+            return "exclude"
+        return "missing"
 
-  if font:
-    row_cells = [
-        CELL_PREFIX + _text_cell(text_dir)
-        for text_dir in ('ltr', 'rtl')]
-  else:
-    row_cells = []
-  row_cells.extend(
-      [CELL_PREFIX + _cell(dir_infos[i], basepaths[i])
-       for i in indices])
-  if len(colors) > 1:
-    ix = indices[-1]
-    extension = CELL_PREFIX + _cell(dir_infos[ix], basepaths[ix])
-    row_cells.extend([extension] * (len(colors) - 1))
-  return row_cells
+    def _text_cell(text_dir):
+        text = "".join(unichr(cp) for cp in key)
+        return '<span class="efont" dir="%s">%s</span>' % (text_dir, text)
+
+    if font:
+        row_cells = [CELL_PREFIX + _text_cell(text_dir) for text_dir in ("ltr", "rtl")]
+    else:
+        row_cells = []
+    row_cells.extend([CELL_PREFIX + _cell(dir_infos[i], basepaths[i]) for i in indices])
+    if len(colors) > 1:
+        ix = indices[-1]
+        extension = CELL_PREFIX + _cell(dir_infos[ix], basepaths[ix])
+        row_cells.extend([extension] * (len(colors) - 1))
+    return row_cells
 
 
 def _get_desc(key_tuple, aliases, dir_infos, basepaths):
-  CELL_PREFIX = '<td>'
-  def _get_filepath(cp):
-    def get_key_filepath(key):
-      for i in range(len(dir_infos)):
-        info = dir_infos[i]
-        if key in info.filemap:
-          basepath = basepaths[i]
-          return path.join(basepath, info.filemap[key])
-      return None
+    CELL_PREFIX = "<td>"
 
-    cp_key = tuple([cp])
-    cp_key = unicode_data.get_canonical_emoji_sequence(cp_key) or cp_key
-    fp = get_key_filepath(cp_key)
-    if not fp:
-      if cp_key in aliases:
-        fp = get_key_filepath(aliases[cp_key])
-      else:
-        print('no alias for %s' % unicode_data.seq_to_string(cp_key))
-    if not fp:
-      print('no part for %s in %s' % (
-          unicode_data.seq_to_string(cp_key),
-          unicode_data.seq_to_string(key_tuple)))
-    return fp
+    def _get_filepath(cp):
+        def get_key_filepath(key):
+            for i in range(len(dir_infos)):
+                info = dir_infos[i]
+                if key in info.filemap:
+                    basepath = basepaths[i]
+                    return path.join(basepath, info.filemap[key])
+            return None
 
-  def _get_part(cp):
-    if cp == 0x200d:  # zwj, common so replace with '+'
-      return '+'
-    if unicode_data.is_regional_indicator(cp):
-      return unicode_data.regional_indicator_to_ascii(cp)
-    if unicode_data.is_tag(cp):
-      return unicode_data.tag_character_to_ascii(cp)
-    fname = _get_filepath(cp)
-    if fname:
-      return '<img src="%s">' % fname
-    raise Exception()
+        cp_key = tuple([cp])
+        cp_key = unicode_data.get_canonical_emoji_sequence(cp_key) or cp_key
+        fp = get_key_filepath(cp_key)
+        if not fp:
+            if cp_key in aliases:
+                fp = get_key_filepath(aliases[cp_key])
+            else:
+                print("no alias for %s" % unicode_data.seq_to_string(cp_key))
+        if not fp:
+            print(
+                "no part for %s in %s"
+                % (
+                    unicode_data.seq_to_string(cp_key),
+                    unicode_data.seq_to_string(key_tuple),
+                )
+            )
+        return fp
 
-  if len(key_tuple) == 1:
-    desc = '%04x' % key_tuple
-  else:
-    desc = ' '.join('%04x' % cp for cp in key_tuple)
-    if len(unicode_data.strip_emoji_vs(key_tuple)) > 1:
-      try:
-        desc += ' (%s)' % ''.join(
-            _get_part(cp) for cp in key_tuple if cp != 0xfe0f)
-      except:
-        pass
-  return CELL_PREFIX + desc
+    def _get_part(cp):
+        if cp == 0x200D:  # zwj, common so replace with '+'
+            return "+"
+        if unicode_data.is_regional_indicator(cp):
+            return unicode_data.regional_indicator_to_ascii(cp)
+        if unicode_data.is_tag(cp):
+            return unicode_data.tag_character_to_ascii(cp)
+        fname = _get_filepath(cp)
+        if fname:
+            return '<img src="%s">' % fname
+        raise Exception()
+
+    if len(key_tuple) == 1:
+        desc = "%04x" % key_tuple
+    else:
+        desc = " ".join("%04x" % cp for cp in key_tuple)
+        if len(unicode_data.strip_emoji_vs(key_tuple)) > 1:
+            try:
+                desc += " (%s)" % "".join(
+                    _get_part(cp) for cp in key_tuple if cp != 0xFE0F
+                )
+            except:
+                pass
+    return CELL_PREFIX + desc
 
 
 def _get_name(key_tuple, annotations):
-  annotation = None if annotations is None else annotations.get(key_tuple)
-  CELL_PREFIX = '<td%s>' % (
-      '' if annotation is None else ' class="%s"' % annotation)
+    annotation = None if annotations is None else annotations.get(key_tuple)
+    CELL_PREFIX = "<td%s>" % ("" if annotation is None else ' class="%s"' % annotation)
 
-  seq_name = unicode_data.get_emoji_sequence_name(key_tuple)
-  if seq_name == None:
-    if key_tuple == (0x20e3,):
-      seq_name = '(combining enlosing keycap)'
-    elif key_tuple == (0xfe82b,):
-      seq_name = '(unknown flag PUA codepoint)'
-    else:
-      print('no name for %s' % unicode_data.seq_to_string(key_tuple))
-      seq_name = '(oops)'
-  return CELL_PREFIX + seq_name
+    seq_name = unicode_data.get_emoji_sequence_name(key_tuple)
+    if seq_name == None:
+        if key_tuple == (0x20E3,):
+            seq_name = "(combining enlosing keycap)"
+        elif key_tuple == (0xFE82B,):
+            seq_name = "(unknown flag PUA codepoint)"
+        else:
+            print("no name for %s" % unicode_data.seq_to_string(key_tuple))
+            seq_name = "(oops)"
+    return CELL_PREFIX + seq_name
 
 
 def _collect_aux_info(dir_infos, keys):
-  """Returns a map from dir_info_index to a set of keys of additional images
-  that we will take from the directory at that index."""
+    """Returns a map from dir_info_index to a set of keys of additional images
+    that we will take from the directory at that index."""
 
-  target_key_to_info_index = {}
-  for key in keys:
-    if len(key) == 1:
-      continue
-    for cp in key:
-      target_key = tuple([cp])
-      if target_key in keys or target_key in target_key_to_info_index:
-        continue
-      for i, info in enumerate(dir_infos):
-        if target_key in info.filemap:
-          target_key_to_info_index[target_key] = i
-          break
-      if target_key not in target_key_to_info_index:
-        # we shouldn't try to use it in the description.  maybe report this?
-        pass
+    target_key_to_info_index = {}
+    for key in keys:
+        if len(key) == 1:
+            continue
+        for cp in key:
+            target_key = tuple([cp])
+            if target_key in keys or target_key in target_key_to_info_index:
+                continue
+            for i, info in enumerate(dir_infos):
+                if target_key in info.filemap:
+                    target_key_to_info_index[target_key] = i
+                    break
+            if target_key not in target_key_to_info_index:
+                # we shouldn't try to use it in the description.  maybe report this?
+                pass
 
-  # now we need to invert the map
-  aux_info = collections.defaultdict(set)
-  for key, index in target_key_to_info_index.items():
-    aux_info[index].add(key)
+    # now we need to invert the map
+    aux_info = collections.defaultdict(set)
+    for key, index in target_key_to_info_index.items():
+        aux_info[index].add(key)
 
-  return aux_info
+    return aux_info
 
 
 def _generate_content(
-    basedir, font, dir_infos, keys, aliases, excluded, annotations, standalone,
-    colors):
-  """Generate an html table for the infos.  Basedir is the parent directory of
-  the content, filenames will be made relative to this if underneath it, else
-  absolute. If font is not none, generate columns for the text rendered in the
-  font before other columns.  Dir_infos is the list of DirInfos in column
-  order.  Keys is the list of canonical emoji sequences in row order.  Aliases
-  and excluded indicate images we expect to not be present either because
-  they are aliased or specifically excluded.  If annotations is not none,
-  highlight sequences that appear in this map based on their map values ('ok',
-  'error', 'warning').  If standalone is true, the image data and font (if used)
-  will be copied under the basedir to make a completely stand-alone page.
-  Colors is the list of background colors, the last DirInfo column will be
-  repeated against each of these backgrounds.
-  """
+    basedir, font, dir_infos, keys, aliases, excluded, annotations, standalone, colors
+):
+    """Generate an html table for the infos.  Basedir is the parent directory of
+    the content, filenames will be made relative to this if underneath it, else
+    absolute. If font is not none, generate columns for the text rendered in the
+    font before other columns.  Dir_infos is the list of DirInfos in column
+    order.  Keys is the list of canonical emoji sequences in row order.  Aliases
+    and excluded indicate images we expect to not be present either because
+    they are aliased or specifically excluded.  If annotations is not none,
+    highlight sequences that appear in this map based on their map values ('ok',
+    'error', 'warning').  If standalone is true, the image data and font (if used)
+    will be copied under the basedir to make a completely stand-alone page.
+    Colors is the list of background colors, the last DirInfo column will be
+    repeated against each of these backgrounds.
+    """
 
-  basedir = path.abspath(path.expanduser(basedir))
-  if not path.isdir(basedir):
-    os.makedirs(basedir)
+    basedir = path.abspath(path.expanduser(basedir))
+    if not path.isdir(basedir):
+        os.makedirs(basedir)
 
-  basepaths = []
+    basepaths = []
 
-  if standalone:
-    # auxiliary images are used in the decomposition of multi-part emoji but
-    # aren't part of main set.  e.g. if we have female basketball player
-    # color-3 we want female, basketball player, and color-3 images available
-    # even if they aren't part of the target set.
-    aux_info = _collect_aux_info(dir_infos, keys)
+    if standalone:
+        # auxiliary images are used in the decomposition of multi-part emoji but
+        # aren't part of main set.  e.g. if we have female basketball player
+        # color-3 we want female, basketball player, and color-3 images available
+        # even if they aren't part of the target set.
+        aux_info = _collect_aux_info(dir_infos, keys)
 
-    # create image subdirectories in target dir, copy image files to them,
-    # and adjust paths
-    for i, info in enumerate(dir_infos):
-      subdir = '%02d' % i
-      dstdir = path.join(basedir, subdir)
-      if not path.isdir(dstdir):
-        os.mkdir(dstdir)
+        # create image subdirectories in target dir, copy image files to them,
+        # and adjust paths
+        for i, info in enumerate(dir_infos):
+            subdir = "%02d" % i
+            dstdir = path.join(basedir, subdir)
+            if not path.isdir(dstdir):
+                os.mkdir(dstdir)
 
-      copy_keys = set(keys) | aux_info[i]
-      srcdir = info.directory
-      filemap = info.filemap
-      for key in copy_keys:
-        if key in filemap:
-          filename = filemap[key]
-          srcfile = path.join(srcdir, filename)
-          dstfile = path.join(dstdir, filename)
-          shutil.copy2(srcfile, dstfile)
-      basepaths.append(subdir)
-  else:
-    for srcdir, _, _ in dir_infos:
-      abs_srcdir = path.abspath(path.expanduser(srcdir))
-      if abs_srcdir == basedir:
-        dirspec = ''
-      elif abs_srcdir.startswith(basedir):
-        dirspec = abs_srcdir[len(basedir) + 1:]
-      else:
-        dirspec = abs_srcdir
-      basepaths.append(dirspec)
+            copy_keys = set(keys) | aux_info[i]
+            srcdir = info.directory
+            filemap = info.filemap
+            for key in copy_keys:
+                if key in filemap:
+                    filename = filemap[key]
+                    srcfile = path.join(srcdir, filename)
+                    dstfile = path.join(dstdir, filename)
+                    shutil.copy2(srcfile, dstfile)
+            basepaths.append(subdir)
+    else:
+        for srcdir, _, _ in dir_infos:
+            abs_srcdir = path.abspath(path.expanduser(srcdir))
+            if abs_srcdir == basedir:
+                dirspec = ""
+            elif abs_srcdir.startswith(basedir):
+                dirspec = abs_srcdir[len(basedir) + 1 :]
+            else:
+                dirspec = abs_srcdir
+            basepaths.append(dirspec)
 
-  lines = ['<table>']
-  header_row = ['']
-  if font:
-    header_row.extend(['Emoji ltr', 'Emoji rtl'])
-  header_row.extend([info.title for info in dir_infos])
-  if len(colors) > 1:
-    header_row.extend([dir_infos[-1].title] * (len(colors) - 1))
-  header_row.extend(['Sequence', 'Name'])
-  lines.append('<th>'.join(header_row))
+    lines = ["<table>"]
+    header_row = [""]
+    if font:
+        header_row.extend(["Emoji ltr", "Emoji rtl"])
+    header_row.extend([info.title for info in dir_infos])
+    if len(colors) > 1:
+        header_row.extend([dir_infos[-1].title] * (len(colors) - 1))
+    header_row.extend(["Sequence", "Name"])
+    lines.append("<th>".join(header_row))
 
-  for key in keys:
-    row = _generate_row_cells(
-        key, font, aliases, excluded, dir_infos, basepaths, colors)
-    row.append(_get_desc(key, aliases, dir_infos, basepaths))
-    row.append(_get_name(key, annotations))
-    lines.append(''.join(row))
+    for key in keys:
+        row = _generate_row_cells(
+            key, font, aliases, excluded, dir_infos, basepaths, colors
+        )
+        row.append(_get_desc(key, aliases, dir_infos, basepaths))
+        row.append(_get_name(key, annotations))
+        lines.append("".join(row))
 
-  return '\n  <tr>'.join(lines) + '\n</table>'
+    return "\n  <tr>".join(lines) + "\n</table>"
 
 
 def _get_image_data(image_dir, ext, prefix):
-  """Return a map from a canonical tuple of cp sequences to a filename.
+    """Return a map from a canonical tuple of cp sequences to a filename.
 
-  This filters by file extension, and expects the rest of the files
-  to match the prefix followed by a sequence of hex codepoints separated
-  by underscore.  Files that don't match, duplicate sequences (because
-  of casing), and out_of_range or empty codepoints raise an error."""
+    This filters by file extension, and expects the rest of the files
+    to match the prefix followed by a sequence of hex codepoints separated
+    by underscore.  Files that don't match, duplicate sequences (because
+    of casing), and out_of_range or empty codepoints raise an error."""
 
-  fails = []
-  result = {}
-  expect_re = re.compile(r'%s([0-9A-Fa-f_]+).%s' % (prefix, ext))
-  for f in sorted(glob.glob(path.join(image_dir, '*.%s' % ext))):
-    filename = path.basename(f)
-    m = expect_re.match(filename)
-    if not m:
-      if filename.startswith('unknown_flag.') or filename.startswith('p4p_'):
-        continue
-      fails.append('"%s" did not match: "%s"' % (expect_re.pattern, filename))
-      continue
-    seq = m.group(1)
-    this_failed = False
-    try:
-      cps = tuple(int(s, 16) for s in seq.split('_'))
-      for cp in cps:
-        if (cp > 0x10ffff):
-          fails.append('cp out of range: ' + filename)
-          this_failed = True
-          break
-      if this_failed:
-        continue
-      canonical_cps = unicode_data.get_canonical_emoji_sequence(cps)
-      if canonical_cps:
-        # if it is unrecognized, just leave it alone, else replace with
-        # canonical sequence.
-        cps = canonical_cps
-    except:
-      fails.append('bad cp sequence: ' + filename)
-      continue
-    if cps in result:
-      fails.append('duplicate sequence: %s and %s' (result[cps], filename))
-      continue
-    result[cps] = filename
-  if fails:
-    print('get_image_data failed (%s, %s, %s):\n  %s' % (
-        image_dir, ext, prefix, '\n  '.join(fails)), file=sys.stderr)
-    raise ValueError('get image data failed')
-  return result
+    fails = []
+    result = {}
+    expect_re = re.compile(r"%s([0-9A-Fa-f_]+).%s" % (prefix, ext))
+    for f in sorted(glob.glob(path.join(image_dir, "*.%s" % ext))):
+        filename = path.basename(f)
+        m = expect_re.match(filename)
+        if not m:
+            if filename.startswith("unknown_flag.") or filename.startswith("p4p_"):
+                continue
+            fails.append('"%s" did not match: "%s"' % (expect_re.pattern, filename))
+            continue
+        seq = m.group(1)
+        this_failed = False
+        try:
+            cps = tuple(int(s, 16) for s in seq.split("_"))
+            for cp in cps:
+                if cp > 0x10FFFF:
+                    fails.append("cp out of range: " + filename)
+                    this_failed = True
+                    break
+            if this_failed:
+                continue
+            canonical_cps = unicode_data.get_canonical_emoji_sequence(cps)
+            if canonical_cps:
+                # if it is unrecognized, just leave it alone, else replace with
+                # canonical sequence.
+                cps = canonical_cps
+        except:
+            fails.append("bad cp sequence: " + filename)
+            continue
+        if cps in result:
+            fails.append("duplicate sequence: %s and %s"(result[cps], filename))
+            continue
+        result[cps] = filename
+    if fails:
+        print(
+            "get_image_data failed (%s, %s, %s):\n  %s"
+            % (image_dir, ext, prefix, "\n  ".join(fails)),
+            file=sys.stderr,
+        )
+        raise ValueError("get image data failed")
+    return result
 
 
 def _get_dir_infos(
-    image_dirs, exts=None, prefixes=None, titles=None,
-    default_ext=_default_ext, default_prefix=_default_prefix):
-  """Return a list of DirInfos for the image_dirs.  When defined,
-  exts, prefixes, and titles should be the same length as image_dirs.
-  Titles default to using the last segments of the image_dirs,
-  exts and prefixes default to the corresponding default values."""
+    image_dirs,
+    exts=None,
+    prefixes=None,
+    titles=None,
+    default_ext=_default_ext,
+    default_prefix=_default_prefix,
+):
+    """Return a list of DirInfos for the image_dirs.  When defined,
+    exts, prefixes, and titles should be the same length as image_dirs.
+    Titles default to using the last segments of the image_dirs,
+    exts and prefixes default to the corresponding default values."""
 
-  count = len(image_dirs)
-  if not titles:
-    titles = [None] * count
-  elif len(titles) != count:
-      raise ValueError('have %d image dirs but %d titles' % (
-          count, len(titles)))
-  if not exts:
-    exts = [default_ext] * count
-  elif len(exts) != count:
-    raise ValueError('have %d image dirs but %d extensions' % (
-        count, len(exts)))
-  if not prefixes:
-    prefixes = [default_prefix] * count
-  elif len(prefixes) != count:
-    raise ValueError('have %d image dirs but %d prefixes' % (
-        count, len(prefixes)))
+    count = len(image_dirs)
+    if not titles:
+        titles = [None] * count
+    elif len(titles) != count:
+        raise ValueError("have %d image dirs but %d titles" % (count, len(titles)))
+    if not exts:
+        exts = [default_ext] * count
+    elif len(exts) != count:
+        raise ValueError("have %d image dirs but %d extensions" % (count, len(exts)))
+    if not prefixes:
+        prefixes = [default_prefix] * count
+    elif len(prefixes) != count:
+        raise ValueError("have %d image dirs but %d prefixes" % (count, len(prefixes)))
 
-  infos = []
-  for i in range(count):
-    image_dir = image_dirs[i]
-    title = titles[i] or path.basename(path.abspath(image_dir))
-    ext = exts[i] or default_ext
-    prefix = prefixes[i] or default_prefix
-    filemap = _get_image_data(image_dir, ext, prefix)
-    infos.append(DirInfo(image_dir, title, filemap))
-  return infos
+    infos = []
+    for i in range(count):
+        image_dir = image_dirs[i]
+        title = titles[i] or path.basename(path.abspath(image_dir))
+        ext = exts[i] or default_ext
+        prefix = prefixes[i] or default_prefix
+        filemap = _get_image_data(image_dir, ext, prefix)
+        infos.append(DirInfo(image_dir, title, filemap))
+    return infos
 
 
 def _add_aliases(keys, aliases):
-  for k, v in sorted(aliases.items()):
-    k_str = unicode_data.seq_to_string(k)
-    v_str = unicode_data.seq_to_string(v)
-    if k in keys:
-      msg = '' if v in keys else ' but it\'s not present'
-      print('have alias image %s, should use %s%s' % (k_str, v_str, msg))
-    elif v not in keys:
-      print('can\'t use alias %s, no image matching %s' % (k_str, v_str))
-  to_add = {k for k, v in aliases.items() if k not in keys and v in keys}
-  return keys | to_add
+    for k, v in sorted(aliases.items()):
+        k_str = unicode_data.seq_to_string(k)
+        v_str = unicode_data.seq_to_string(v)
+        if k in keys:
+            msg = "" if v in keys else " but it's not present"
+            print("have alias image %s, should use %s%s" % (k_str, v_str, msg))
+        elif v not in keys:
+            print("can't use alias %s, no image matching %s" % (k_str, v_str))
+    to_add = {k for k, v in aliases.items() if k not in keys and v in keys}
+    return keys | to_add
 
 
 def _get_keys(dir_infos, aliases, limit, all_emoji, emoji_sort, ignore_missing):
-  """Return a list of the key tuples to display.  If all_emoji is
-  true, start with all emoji sequences, else the sequences available
-  in dir_infos (limited to the first dir_info if limit is True).
-  If ignore_missing is true and all_emoji is false, ignore sequences
-  that are not valid (e.g. skin tone variants of wrestlers).  If
-  ignore_missing is true and all_emoji is true, ignore sequences
-  for which we have no assets (e.g. newly defined emoji).  If not using
-  all_emoji, aliases are included if we have a target for them.
-  The result is in emoji order if emoji_sort is true, else in
-  unicode codepoint order."""
+    """Return a list of the key tuples to display.  If all_emoji is
+    true, start with all emoji sequences, else the sequences available
+    in dir_infos (limited to the first dir_info if limit is True).
+    If ignore_missing is true and all_emoji is false, ignore sequences
+    that are not valid (e.g. skin tone variants of wrestlers).  If
+    ignore_missing is true and all_emoji is true, ignore sequences
+    for which we have no assets (e.g. newly defined emoji).  If not using
+    all_emoji, aliases are included if we have a target for them.
+    The result is in emoji order if emoji_sort is true, else in
+    unicode codepoint order."""
 
-  if all_emoji or ignore_missing:
-    all_keys = unicode_data.get_emoji_sequences()
-  if not all_emoji or ignore_missing:
-    if len(dir_infos) == 1 or limit:
-      avail_keys = frozenset(dir_infos[0].filemap.keys())
+    if all_emoji or ignore_missing:
+        all_keys = unicode_data.get_emoji_sequences()
+    if not all_emoji or ignore_missing:
+        if len(dir_infos) == 1 or limit:
+            avail_keys = frozenset(dir_infos[0].filemap.keys())
+        else:
+            avail_keys = _merge_keys([info.filemap for info in dir_infos])
+        if aliases:
+            avail_keys = _add_aliases(avail_keys, aliases)
+
+    if not ignore_missing:
+        keys = all_keys if all_emoji else avail_keys
     else:
-      avail_keys = _merge_keys([info.filemap for info in dir_infos])
-    if aliases:
-      avail_keys = _add_aliases(avail_keys, aliases)
+        keys = set(all_keys) & avail_keys
 
-  if not ignore_missing:
-    keys = all_keys if all_emoji else avail_keys
-  else:
-    keys = set(all_keys) & avail_keys
-
-  if emoji_sort:
-    sorted_keys = unicode_data.get_sorted_emoji_sequences(keys)
-  else:
-    sorted_keys = sorted(keys)
-  return sorted_keys
+    if emoji_sort:
+        sorted_keys = unicode_data.get_sorted_emoji_sequences(keys)
+    else:
+        sorted_keys = sorted(keys)
+    return sorted_keys
 
 
 def _generate_info_text(args):
-  lines = ['%s: %r' % t for t in sorted(args.__dict__.items())]
-  lines.append('generated by %s on %s' % (
-      path.basename(__file__), datetime.datetime.now()))
-  return '\n  '.join(lines)
+    lines = ["%s: %r" % t for t in sorted(args.__dict__.items())]
+    lines.append(
+        "generated by %s on %s" % (path.basename(__file__), datetime.datetime.now())
+    )
+    return "\n  ".join(lines)
 
 
 def _parse_annotation_file(afile):
-  """Parse file and return a map from sequences to one of 'ok', 'warning',
-  or 'error'.
+    """Parse file and return a map from sequences to one of 'ok', 'warning',
+    or 'error'.
 
-  The file format consists of two kinds of lines.  One defines the annotation
-  to apply, it consists of the text 'annotation:' followed by one of 'ok',
-  'warning', or 'error'.  The other defines a sequence that should get the most
-  recently defined annotation, this is a series of codepoints expressed in hex
-  separated by spaces.  The initial default annotation is 'error'.  '#' starts
-  a comment to end of line, blank lines are ignored.
-  """
+    The file format consists of two kinds of lines.  One defines the annotation
+    to apply, it consists of the text 'annotation:' followed by one of 'ok',
+    'warning', or 'error'.  The other defines a sequence that should get the most
+    recently defined annotation, this is a series of codepoints expressed in hex
+    separated by spaces.  The initial default annotation is 'error'.  '#' starts
+    a comment to end of line, blank lines are ignored.
+    """
 
-  annotations = {}
-  line_re = re.compile(r'annotation:\s*(ok|warning|error)|([0-9a-f ]+)')
-  annotation = 'error'
-  with open(afile, 'r') as f:
-    for line in f:
-      line = line.strip()
-      if not line or line[0] == '#':
-        continue
-      m = line_re.match(line)
-      if not m:
-        raise Exception('could not parse annotation "%s"' % line)
-      new_annotation = m.group(1)
-      if new_annotation:
-        annotation = new_annotation
-      else:
-        seq = tuple([int(s, 16) for s in m.group(2).split()])
-        canonical_seq = unicode_data.get_canonical_emoji_sequence(seq)
-        if canonical_seq:
-          seq = canonical_seq
-        if seq in annotations:
-          raise Exception(
-              'duplicate sequence %s in annotations' %
-              unicode_data.seq_to_string(seq))
-        annotations[seq] = annotation
-  return annotations
+    annotations = {}
+    line_re = re.compile(r"annotation:\s*(ok|warning|error)|([0-9a-f ]+)")
+    annotation = "error"
+    with open(afile, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line[0] == "#":
+                continue
+            m = line_re.match(line)
+            if not m:
+                raise Exception('could not parse annotation "%s"' % line)
+            new_annotation = m.group(1)
+            if new_annotation:
+                annotation = new_annotation
+            else:
+                seq = tuple([int(s, 16) for s in m.group(2).split()])
+                canonical_seq = unicode_data.get_canonical_emoji_sequence(seq)
+                if canonical_seq:
+                    seq = canonical_seq
+                if seq in annotations:
+                    raise Exception(
+                        "duplicate sequence %s in annotations"
+                        % unicode_data.seq_to_string(seq)
+                    )
+                annotations[seq] = annotation
+    return annotations
 
 
 def _instantiate_template(template, arg_dict):
-  id_regex = re.compile(r'\$([a-zA-Z0-9_]+)')
-  ids = set(m.group(1) for m in id_regex.finditer(template))
-  keyset = set(arg_dict.keys())
-  extra_args = keyset - ids
-  if extra_args:
-    print((
-        'the following %d args are unused:\n%s' %
-        (len(extra_args), ', '.join(sorted(extra_args)))), file=sys.stderr)
-  return string.Template(template).substitute(arg_dict)
+    id_regex = re.compile(r"\$([a-zA-Z0-9_]+)")
+    ids = set(m.group(1) for m in id_regex.finditer(template))
+    keyset = set(arg_dict.keys())
+    extra_args = keyset - ids
+    if extra_args:
+        print(
+            (
+                "the following %d args are unused:\n%s"
+                % (len(extra_args), ", ".join(sorted(extra_args)))
+            ),
+            file=sys.stderr,
+        )
+    return string.Template(template).substitute(arg_dict)
 
 
 TEMPLATE = """<!DOCTYPE html>
@@ -489,153 +503,235 @@ STYLE = """
       td.ok { background-color: rgb(10, 200, 60) }
 """
 
+
 def write_html_page(
-    filename, page_title, font, dir_infos, keys, aliases, excluded, annotations,
-    standalone, colors, info):
+    filename,
+    page_title,
+    font,
+    dir_infos,
+    keys,
+    aliases,
+    excluded,
+    annotations,
+    standalone,
+    colors,
+    info,
+):
+    out_dir = path.dirname(filename)
+    if font:
+        if standalone:
+            # the assumption with standalone is that the source data and
+            # output directory don't overlap, this should probably be checked...
 
-  out_dir = path.dirname(filename)
-  if font:
-    if standalone:
-      # the assumption with standalone is that the source data and
-      # output directory don't overlap, this should probably be checked...
+            rel_fontpath = path.join("font", path.basename(font))
+            new_font = path.join(out_dir, rel_fontpath)
+            tool_utils.ensure_dir_exists(path.dirname(new_font))
+            shutil.copy2(font, new_font)
+            font = rel_fontpath
+        else:
+            common_prefix, (rel_dir, rel_font) = tool_utils.commonpathprefix(
+                [out_dir, font]
+            )
+            if rel_dir == "":
+                # font is in a subdirectory of the target, so just use the relative
+                # path
+                font = rel_font
+            else:
+                # use the absolute path
+                font = path.normpath(path.join(common_prefix, rel_font))
 
-      rel_fontpath = path.join('font', path.basename(font))
-      new_font = path.join(out_dir, rel_fontpath)
-      tool_utils.ensure_dir_exists(path.dirname(new_font))
-      shutil.copy2(font, new_font)
-      font = rel_fontpath
-    else:
-      common_prefix, (rel_dir, rel_font) = tool_utils.commonpathprefix(
-          [out_dir, font])
-      if rel_dir == '':
-        # font is in a subdirectory of the target, so just use the relative
-        # path
-        font = rel_font
-      else:
-        # use the absolute path
-        font = path.normpath(path.join(common_prefix, rel_font))
-
-  content = _generate_content(
-      path.dirname(filename), font, dir_infos, keys, aliases, excluded,
-      annotations, standalone, colors)
-  N_STYLE = STYLE
-  if font:
-    FONT_FACE_STYLE = """
+    content = _generate_content(
+        path.dirname(filename),
+        font,
+        dir_infos,
+        keys,
+        aliases,
+        excluded,
+        annotations,
+        standalone,
+        colors,
+    )
+    N_STYLE = STYLE
+    if font:
+        FONT_FACE_STYLE = (
+            """
     <style>@font-face {
       font-family: "Emoji"; src: local("Noto Color Emoji"), url("%s");
-    }</style>""" % font
-    N_STYLE += '      span.efont { font-family: "Emoji"; font-size:32pt }\n'
-  else:
-    FONT_FACE_STYLE = ''
-  num_final_cols = len(colors)
-  col_colors = ['']
-  for i, color in enumerate(colors):
-    col_colors.append(
-        """td:nth-last-of-type(%d) { background-color: #%s }\n""" % (
-            2 + num_final_cols - i, color))
-  N_STYLE += '       '.join(col_colors)
-  text = _instantiate_template(
-      TEMPLATE, {
-          'title': page_title, 'fontFaceStyle': FONT_FACE_STYLE,
-          'style': N_STYLE, 'content': content, 'info':info})
-  with codecs.open(filename, 'w', 'utf-8') as f:
-    f.write(text)
+    }</style>"""
+            % font
+        )
+        N_STYLE += '      span.efont { font-family: "Emoji"; font-size:32pt }\n'
+    else:
+        FONT_FACE_STYLE = ""
+    num_final_cols = len(colors)
+    col_colors = [""]
+    for i, color in enumerate(colors):
+        col_colors.append(
+            """td:nth-last-of-type(%d) { background-color: #%s }\n"""
+            % (2 + num_final_cols - i, color)
+        )
+    N_STYLE += "       ".join(col_colors)
+    text = _instantiate_template(
+        TEMPLATE,
+        {
+            "title": page_title,
+            "fontFaceStyle": FONT_FACE_STYLE,
+            "style": N_STYLE,
+            "content": content,
+            "info": info,
+        },
+    )
+    with codecs.open(filename, "w", "utf-8") as f:
+        f.write(text)
 
 
 def _get_canonical_aliases():
-  def canon(seq):
-    return unicode_data.get_canonical_emoji_sequence(seq) or seq
-  aliases = add_aliases.read_default_emoji_aliases()
-  return {canon(k): canon(v) for k, v in aliases.items()}
+    def canon(seq):
+        return unicode_data.get_canonical_emoji_sequence(seq) or seq
+
+    aliases = add_aliases.read_default_emoji_aliases()
+    return {canon(k): canon(v) for k, v in aliases.items()}
+
 
 def _get_canonical_excluded():
-  def canon(seq):
-    return unicode_data.get_canonical_emoji_sequence(seq) or seq
-  aliases = add_aliases.read_default_unknown_flag_aliases()
-  return frozenset([canon(k) for k in aliases.keys()])
+    def canon(seq):
+        return unicode_data.get_canonical_emoji_sequence(seq) or seq
+
+    aliases = add_aliases.read_default_unknown_flag_aliases()
+    return frozenset([canon(k) for k in aliases.keys()])
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-o', '--outfile', help='path to output file', metavar='file',
-      required=True)
-  parser.add_argument(
-      '--page_title', help='page title', metavar='title', default='Emoji Table')
-  parser.add_argument(
-      '-d', '--image_dirs', help='image directories', metavar='dir',
-      nargs='+')
-  parser.add_argument(
-      '-e', '--exts', help='file extension, one per image dir', metavar='ext',
-      nargs='*')
-  parser.add_argument(
-      '-p', '--prefixes', help='file name prefix, one per image dir',
-      metavar='prefix', nargs='*')
-  parser.add_argument(
-      '-t', '--titles', help='title, one per image dir', metavar='title',
-      nargs='*'),
-  parser.add_argument(
-      '-l', '--limit', help='limit to only sequences supported by first set',
-      action='store_true')
-  parser.add_argument(
-      '-de', '--default_ext', help='default extension', metavar='ext',
-      default=_default_ext)
-  parser.add_argument(
-      '-dp', '--default_prefix', help='default prefix', metavar='prefix',
-      default=_default_prefix)
-  parser.add_argument(
-      '-f', '--font', help='emoji font', metavar='font')
-  parser.add_argument(
-      '-a', '--annotate', help='file listing sequences to annotate',
-      metavar='file')
-  parser.add_argument(
-      '-s', '--standalone', help='copy resources used by html under target dir',
-      action='store_true')
-  parser.add_argument(
-      '-c', '--colors', help='list of colors for background', nargs='*',
-      metavar='hex')
-  parser.add_argument(
-      '--all_emoji', help='use all emoji sequences', action='store_true')
-  parser.add_argument(
-      '--emoji_sort', help='use emoji sort order', action='store_true')
-  parser.add_argument(
-      '--ignore_missing', help='do not include missing emoji',
-      action='store_true')
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-o", "--outfile", help="path to output file", metavar="file", required=True
+    )
+    parser.add_argument(
+        "--page_title", help="page title", metavar="title", default="Emoji Table"
+    )
+    parser.add_argument(
+        "-d", "--image_dirs", help="image directories", metavar="dir", nargs="+"
+    )
+    parser.add_argument(
+        "-e",
+        "--exts",
+        help="file extension, one per image dir",
+        metavar="ext",
+        nargs="*",
+    )
+    parser.add_argument(
+        "-p",
+        "--prefixes",
+        help="file name prefix, one per image dir",
+        metavar="prefix",
+        nargs="*",
+    )
+    (
+        parser.add_argument(
+            "-t",
+            "--titles",
+            help="title, one per image dir",
+            metavar="title",
+            nargs="*",
+        ),
+    )
+    parser.add_argument(
+        "-l",
+        "--limit",
+        help="limit to only sequences supported by first set",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-de",
+        "--default_ext",
+        help="default extension",
+        metavar="ext",
+        default=_default_ext,
+    )
+    parser.add_argument(
+        "-dp",
+        "--default_prefix",
+        help="default prefix",
+        metavar="prefix",
+        default=_default_prefix,
+    )
+    parser.add_argument("-f", "--font", help="emoji font", metavar="font")
+    parser.add_argument(
+        "-a", "--annotate", help="file listing sequences to annotate", metavar="file"
+    )
+    parser.add_argument(
+        "-s",
+        "--standalone",
+        help="copy resources used by html under target dir",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c", "--colors", help="list of colors for background", nargs="*", metavar="hex"
+    )
+    parser.add_argument(
+        "--all_emoji", help="use all emoji sequences", action="store_true"
+    )
+    parser.add_argument(
+        "--emoji_sort", help="use emoji sort order", action="store_true"
+    )
+    parser.add_argument(
+        "--ignore_missing", help="do not include missing emoji", action="store_true"
+    )
 
-  args = parser.parse_args()
-  file_parts = path.splitext(args.outfile)
-  if file_parts[1] != '.html':
-    args.outfile = file_parts[0] + '.html'
-    print('added .html extension to filename:\n%s' % args.outfile)
+    args = parser.parse_args()
+    file_parts = path.splitext(args.outfile)
+    if file_parts[1] != ".html":
+        args.outfile = file_parts[0] + ".html"
+        print("added .html extension to filename:\n%s" % args.outfile)
 
-  if args.annotate:
-    annotations = _parse_annotation_file(args.annotate)
-  else:
-    annotations = None
+    if args.annotate:
+        annotations = _parse_annotation_file(args.annotate)
+    else:
+        annotations = None
 
-  if args.colors == None:
-    args.colors = ['6e6e6e']
-  elif not args.colors:
-    args.colors = """eceff1 f5f5f5 e4e7e9 d9dbdd 080808 263238 21272b 3c474c
+    if args.colors == None:
+        args.colors = ["6e6e6e"]
+    elif not args.colors:
+        args.colors = """eceff1 f5f5f5 e4e7e9 d9dbdd 080808 263238 21272b 3c474c
     4db6ac 80cbc4 5e35b1""".split()
 
-  dir_infos = _get_dir_infos(
-      args.image_dirs, args.exts, args.prefixes, args.titles,
-      args.default_ext, args.default_prefix)
+    dir_infos = _get_dir_infos(
+        args.image_dirs,
+        args.exts,
+        args.prefixes,
+        args.titles,
+        args.default_ext,
+        args.default_prefix,
+    )
 
-  aliases = _get_canonical_aliases()
-  keys = _get_keys(
-      dir_infos, aliases, args.limit, args.all_emoji, args.emoji_sort,
-      args.ignore_missing)
+    aliases = _get_canonical_aliases()
+    keys = _get_keys(
+        dir_infos,
+        aliases,
+        args.limit,
+        args.all_emoji,
+        args.emoji_sort,
+        args.ignore_missing,
+    )
 
-  excluded = _get_canonical_excluded()
+    excluded = _get_canonical_excluded()
 
-  info = _generate_info_text(args)
+    info = _generate_info_text(args)
 
-  write_html_page(
-      args.outfile, args.page_title, args.font, dir_infos, keys, aliases,
-      excluded, annotations, args.standalone, args.colors, info)
+    write_html_page(
+        args.outfile,
+        args.page_title,
+        args.font,
+        dir_infos,
+        keys,
+        aliases,
+        excluded,
+        annotations,
+        args.standalone,
+        args.colors,
+        info,
+    )
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/generate_emoji_name_data.py
+++ b/generate_emoji_name_data.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 """Generate name data for emoji resources. Currently in json format."""
+
 from __future__ import print_function
 
 import argparse
@@ -32,121 +33,125 @@ import generate_emoji_html
 from nototools import tool_utils
 from nototools import unicode_data
 
-def _create_custom_gendered_seq_names():
-  """The names have detail that is adequately represented by the image."""
 
-  BOY = 0x1f466
-  GIRL = 0x1f467
-  MAN = 0x1f468
-  WOMAN = 0x1f469
-  HEART = 0x2764  # Heavy Black Heart
-  KISS_MARK = 0x1f48b
-  return {
-      (MAN, HEART, KISS_MARK, MAN): 'Kiss',
-      (WOMAN, HEART, KISS_MARK, WOMAN): 'Kiss',
-      (WOMAN, HEART, KISS_MARK, MAN): 'Kiss',
-      (WOMAN, HEART, MAN): 'Couple with Heart',
-      (MAN, HEART, MAN): 'Couple with Heart',
-      (WOMAN, HEART, WOMAN): 'Couple with Heart',
-      (MAN, GIRL): 'Family',
-      (MAN, GIRL, GIRL): 'Family',
-      (MAN, GIRL, BOY): 'Family',
-      (MAN, BOY): 'Family',
-      (MAN, BOY, BOY): 'Family',
-      (MAN, WOMAN, GIRL): 'Family',
-      (MAN, WOMAN, GIRL, GIRL): 'Family',
-      (MAN, WOMAN, GIRL, BOY): 'Family',
-      (MAN, WOMAN, BOY): 'Family',
-      (MAN, WOMAN, BOY, BOY): 'Family',
-      (MAN, MAN, GIRL): 'Family',
-      (MAN, MAN, GIRL, GIRL): 'Family',
-      (MAN, MAN, GIRL, BOY): 'Family',
-      (MAN, MAN, BOY): 'Family',
-      (MAN, MAN, BOY, BOY): 'Family',
-      (WOMAN, GIRL): 'Family',
-      (WOMAN, GIRL, GIRL): 'Family',
-      (WOMAN, GIRL, BOY): 'Family',
-      (WOMAN, BOY): 'Family',
-      (WOMAN, BOY, BOY): 'Family',
-      (WOMAN, WOMAN, GIRL): 'Family',
-      (WOMAN, WOMAN, GIRL, GIRL): 'Family',
-      (WOMAN, WOMAN, GIRL, BOY): 'Family',
-      (WOMAN, WOMAN, BOY): 'Family',
-      (WOMAN, WOMAN, BOY, BOY): 'Family' }
+def _create_custom_gendered_seq_names():
+    """The names have detail that is adequately represented by the image."""
+
+    BOY = 0x1F466
+    GIRL = 0x1F467
+    MAN = 0x1F468
+    WOMAN = 0x1F469
+    HEART = 0x2764  # Heavy Black Heart
+    KISS_MARK = 0x1F48B
+    return {
+        (MAN, HEART, KISS_MARK, MAN): "Kiss",
+        (WOMAN, HEART, KISS_MARK, WOMAN): "Kiss",
+        (WOMAN, HEART, KISS_MARK, MAN): "Kiss",
+        (WOMAN, HEART, MAN): "Couple with Heart",
+        (MAN, HEART, MAN): "Couple with Heart",
+        (WOMAN, HEART, WOMAN): "Couple with Heart",
+        (MAN, GIRL): "Family",
+        (MAN, GIRL, GIRL): "Family",
+        (MAN, GIRL, BOY): "Family",
+        (MAN, BOY): "Family",
+        (MAN, BOY, BOY): "Family",
+        (MAN, WOMAN, GIRL): "Family",
+        (MAN, WOMAN, GIRL, GIRL): "Family",
+        (MAN, WOMAN, GIRL, BOY): "Family",
+        (MAN, WOMAN, BOY): "Family",
+        (MAN, WOMAN, BOY, BOY): "Family",
+        (MAN, MAN, GIRL): "Family",
+        (MAN, MAN, GIRL, GIRL): "Family",
+        (MAN, MAN, GIRL, BOY): "Family",
+        (MAN, MAN, BOY): "Family",
+        (MAN, MAN, BOY, BOY): "Family",
+        (WOMAN, GIRL): "Family",
+        (WOMAN, GIRL, GIRL): "Family",
+        (WOMAN, GIRL, BOY): "Family",
+        (WOMAN, BOY): "Family",
+        (WOMAN, BOY, BOY): "Family",
+        (WOMAN, WOMAN, GIRL): "Family",
+        (WOMAN, WOMAN, GIRL, GIRL): "Family",
+        (WOMAN, WOMAN, GIRL, BOY): "Family",
+        (WOMAN, WOMAN, BOY): "Family",
+        (WOMAN, WOMAN, BOY, BOY): "Family",
+    }
+
 
 def _create_custom_seq_names():
-  """These have names that often are of the form 'Person xyz-ing' or 'Man Xyz.'
-  We opt to simplify the former to an activity name or action, and the latter to
-  drop the gender.  This also generally makes the names shorter."""
+    """These have names that often are of the form 'Person xyz-ing' or 'Man Xyz.'
+    We opt to simplify the former to an activity name or action, and the latter to
+    drop the gender.  This also generally makes the names shorter."""
 
-  EYE = 0x1f441
-  SPEECH = 0x1f5e8
-  WHITE_FLAG = 0x1f3f3
-  RAINBOW = 0x1f308
-  return {
-      (EYE, SPEECH): 'I Witness',
-      (WHITE_FLAG, RAINBOW): 'Rainbow Flag',
-      (0x2695,): 'Health Worker',
-      (0x2696,): 'Judge',
-      (0x26f7,): 'Skiing',
-      (0x26f9,): 'Bouncing a Ball',
-      (0x2708,): 'Pilot',
-      (0x1f33e,): 'Farmer',
-      (0x1f373,): 'Cook',
-      (0x1f393,): 'Student',
-      (0x1f3a4,): 'Singer',
-      (0x1f3a8,): 'Artist',
-      (0x1f3c2,): 'Snowboarding',
-      (0x1f3c3,): 'Running',
-      (0x1f3c4,): 'Surfing',
-      (0x1f3ca,): 'Swimming',
-      (0x1f3cb,): 'Weight Lifting',
-      (0x1f3cc,): 'Golfing',
-      (0x1f3eb,): 'Teacher',
-      (0x1f3ed,): 'Factory Worker',
-      (0x1f46e,): 'Police Officer',
-      (0x1f46f,): 'Partying',
-      (0x1f471,): 'Person with Blond Hair',
-      (0x1f473,): 'Person Wearing Turban',
-      (0x1f477,): 'Construction Worker',
-      (0x1f481,): 'Tipping Hand',
-      (0x1f482,): 'Guard',
-      (0x1f486,): 'Face Massage',
-      (0x1f487,): 'Haircut',
-      (0x1f4bb,): 'Technologist',
-      (0x1f4bc,): 'Office Worker',
-      (0x1f527,): 'Mechanic',
-      (0x1f52c,): 'Scientist',
-      (0x1f575,): 'Detective',
-      (0x1f645,): 'No Good Gesture',
-      (0x1f646,): 'OK Gesture',
-      (0x1f647,): 'Bowing Deeply',
-      (0x1f64b,): 'Raising Hand',
-      (0x1f64d,): 'Frowning',
-      (0x1f64e,): 'Pouting',
-      (0x1f680,): 'Astronaut',
-      (0x1f692,): 'Firefighter',
-      (0x1f6a3,): 'Rowing',
-      (0x1f6b4,): 'Bicycling',
-      (0x1f6b5,): 'Mountain Biking',
-      (0x1f6b6,): 'Walking',
-      (0x1f926,): 'Face Palm',
-      (0x1f937,): 'Shrug',
-      (0x1f938,): 'Doing a Cartwheel',
-      (0x1f939,): 'Juggling',
-      (0x1f93c,): 'Wrestling',
-      (0x1f93d,): 'Water Polo',
-      (0x1f93e,): 'Playing Handball',
-      (0x1f9d6,): 'Person in Steamy Room',
-      (0x1f9d7,): 'Climbing',
-      (0x1f9d8,): 'Person in Lotus Position',
-      (0x1f9d9,): 'Mage',
-      (0x1f9da,): 'Fairy',
-      (0x1f9db,): 'Vampire',
-      (0x1f9dd,): 'Elf',
-      (0x1f9de,): 'Genie',
-      (0x1f9df,): 'Zombie',
-  }
+    EYE = 0x1F441
+    SPEECH = 0x1F5E8
+    WHITE_FLAG = 0x1F3F3
+    RAINBOW = 0x1F308
+    return {
+        (EYE, SPEECH): "I Witness",
+        (WHITE_FLAG, RAINBOW): "Rainbow Flag",
+        (0x2695,): "Health Worker",
+        (0x2696,): "Judge",
+        (0x26F7,): "Skiing",
+        (0x26F9,): "Bouncing a Ball",
+        (0x2708,): "Pilot",
+        (0x1F33E,): "Farmer",
+        (0x1F373,): "Cook",
+        (0x1F393,): "Student",
+        (0x1F3A4,): "Singer",
+        (0x1F3A8,): "Artist",
+        (0x1F3C2,): "Snowboarding",
+        (0x1F3C3,): "Running",
+        (0x1F3C4,): "Surfing",
+        (0x1F3CA,): "Swimming",
+        (0x1F3CB,): "Weight Lifting",
+        (0x1F3CC,): "Golfing",
+        (0x1F3EB,): "Teacher",
+        (0x1F3ED,): "Factory Worker",
+        (0x1F46E,): "Police Officer",
+        (0x1F46F,): "Partying",
+        (0x1F471,): "Person with Blond Hair",
+        (0x1F473,): "Person Wearing Turban",
+        (0x1F477,): "Construction Worker",
+        (0x1F481,): "Tipping Hand",
+        (0x1F482,): "Guard",
+        (0x1F486,): "Face Massage",
+        (0x1F487,): "Haircut",
+        (0x1F4BB,): "Technologist",
+        (0x1F4BC,): "Office Worker",
+        (0x1F527,): "Mechanic",
+        (0x1F52C,): "Scientist",
+        (0x1F575,): "Detective",
+        (0x1F645,): "No Good Gesture",
+        (0x1F646,): "OK Gesture",
+        (0x1F647,): "Bowing Deeply",
+        (0x1F64B,): "Raising Hand",
+        (0x1F64D,): "Frowning",
+        (0x1F64E,): "Pouting",
+        (0x1F680,): "Astronaut",
+        (0x1F692,): "Firefighter",
+        (0x1F6A3,): "Rowing",
+        (0x1F6B4,): "Bicycling",
+        (0x1F6B5,): "Mountain Biking",
+        (0x1F6B6,): "Walking",
+        (0x1F926,): "Face Palm",
+        (0x1F937,): "Shrug",
+        (0x1F938,): "Doing a Cartwheel",
+        (0x1F939,): "Juggling",
+        (0x1F93C,): "Wrestling",
+        (0x1F93D,): "Water Polo",
+        (0x1F93E,): "Playing Handball",
+        (0x1F9D6,): "Person in Steamy Room",
+        (0x1F9D7,): "Climbing",
+        (0x1F9D8,): "Person in Lotus Position",
+        (0x1F9D9,): "Mage",
+        (0x1F9DA,): "Fairy",
+        (0x1F9DB,): "Vampire",
+        (0x1F9DD,): "Elf",
+        (0x1F9DE,): "Genie",
+        (0x1F9DF,): "Zombie",
+    }
+
 
 _CUSTOM_GENDERED_SEQ_NAMES = _create_custom_gendered_seq_names()
 _CUSTOM_SEQ_NAMES = _create_custom_seq_names()
@@ -155,35 +160,35 @@ _CUSTOM_SEQ_NAMES = _create_custom_seq_names()
 # Also prevents titlecasing 'S' after apostrophe in posessives.  Note we _do_
 # want titlecasing after apostrophe in some cases, e.g. O'Clock.
 _CUSTOM_CAPS_NAMES = {
-    (0x26d1,): 'Rescue Worker’s Helmet',
-    (0x1f170,): 'A Button (blood type)',  # a Button (Blood Type)
-    (0x1f171,): 'B Button (blood type)',  # B Button (Blood Type)
-    (0x1f17e,): 'O Button (blood type)',  # O Button (Blood Type)
-    (0x1f18e,): 'AB Button (blood type)',  # Ab Button (Blood Type)
-    (0x1f191,): 'CL Button',  # Cl Button
-    (0x1f192,): 'COOL Button',  # Cool Button
-    (0x1f193,): 'FREE Button',  # Free Button
-    (0x1f194,): 'ID Button',  # Id Button
-    (0x1f195,): 'NEW Button',  # New Button
-    (0x1f196,): 'NG Button',  # Ng Button
-    (0x1f197,): 'OK Button',  # Ok Button
-    (0x1f198,): 'SOS Button',  # Sos Button
-    (0x1f199,): 'UP! Button',  # Up! Button
-    (0x1f19a,): 'VS Button',  # Vs Button
-    (0x1f3e7,): 'ATM Sign',  # Atm Sign
-    (0x1f44C,): 'OK Hand',  # Ok Hand
-    (0x1f452,): 'Woman’s Hat',
-    (0x1f45a,): 'Woman’s Clothes',
-    (0x1f45e,): 'Man’s Shoe',
-    (0x1f461,): 'Woman’s Sandal',
-    (0x1f462,): 'Woman’s Boot',
-    (0x1f519,): 'BACK Arrow',  # Back Arrow
-    (0x1f51a,): 'END Arrow',  # End Arrow
-    (0x1f51b,): 'ON! Arrow',  # On! Arrow
-    (0x1f51c,): 'SOON Arrow',  # Soon Arrow
-    (0x1f51d,): 'TOP Arrow',  # Top Arrow
-    (0x1f6b9,): 'Men’s Room',
-    (0x1f6ba,): 'Women’s Room',
+    (0x26D1,): "Rescue Worker’s Helmet",
+    (0x1F170,): "A Button (blood type)",  # a Button (Blood Type)
+    (0x1F171,): "B Button (blood type)",  # B Button (Blood Type)
+    (0x1F17E,): "O Button (blood type)",  # O Button (Blood Type)
+    (0x1F18E,): "AB Button (blood type)",  # Ab Button (Blood Type)
+    (0x1F191,): "CL Button",  # Cl Button
+    (0x1F192,): "COOL Button",  # Cool Button
+    (0x1F193,): "FREE Button",  # Free Button
+    (0x1F194,): "ID Button",  # Id Button
+    (0x1F195,): "NEW Button",  # New Button
+    (0x1F196,): "NG Button",  # Ng Button
+    (0x1F197,): "OK Button",  # Ok Button
+    (0x1F198,): "SOS Button",  # Sos Button
+    (0x1F199,): "UP! Button",  # Up! Button
+    (0x1F19A,): "VS Button",  # Vs Button
+    (0x1F3E7,): "ATM Sign",  # Atm Sign
+    (0x1F44C,): "OK Hand",  # Ok Hand
+    (0x1F452,): "Woman’s Hat",
+    (0x1F45A,): "Woman’s Clothes",
+    (0x1F45E,): "Man’s Shoe",
+    (0x1F461,): "Woman’s Sandal",
+    (0x1F462,): "Woman’s Boot",
+    (0x1F519,): "BACK Arrow",  # Back Arrow
+    (0x1F51A,): "END Arrow",  # End Arrow
+    (0x1F51B,): "ON! Arrow",  # On! Arrow
+    (0x1F51C,): "SOON Arrow",  # Soon Arrow
+    (0x1F51D,): "TOP Arrow",  # Top Arrow
+    (0x1F6B9,): "Men’s Room",
+    (0x1F6BA,): "Women’s Room",
 }
 
 # For the custom sequences we ignore ZWJ, the emoji variation selector
@@ -192,213 +197,267 @@ _CUSTOM_CAPS_NAMES = {
 # cases so we define a separate set of gendered emoji to remove.
 
 _NON_GENDER_CPS_TO_STRIP = frozenset(
-    [0xfe0f, 0x200d] +
-    range(unicode_data._FITZ_START, unicode_data._FITZ_END + 1))
+    [0xFE0F, 0x200D] + range(unicode_data._FITZ_START, unicode_data._FITZ_END + 1)
+)
 
-_GENDER_CPS_TO_STRIP = frozenset([0x2640, 0x2642, 0x1f468, 0x1f469])
+_GENDER_CPS_TO_STRIP = frozenset([0x2640, 0x2642, 0x1F468, 0x1F469])
+
 
 def _custom_name(seq):
-  """Apply three kinds of custom names, based on the sequence."""
+    """Apply three kinds of custom names, based on the sequence."""
 
-  seq = tuple([cp for cp in seq if cp not in _NON_GENDER_CPS_TO_STRIP])
-  name = _CUSTOM_CAPS_NAMES.get(seq)
-  if name:
+    seq = tuple([cp for cp in seq if cp not in _NON_GENDER_CPS_TO_STRIP])
+    name = _CUSTOM_CAPS_NAMES.get(seq)
+    if name:
+        return name
+
+    # Single characters that participate in sequences (e.g. fire truck in the
+    # firefighter sequences) should not get converted.  Single characters
+    # are in the custom caps names set but not the other sets.
+    if len(seq) == 1:
+        return None
+
+    name = _CUSTOM_GENDERED_SEQ_NAMES.get(seq)
+    if name:
+        return name
+
+    seq = tuple([cp for cp in seq if cp not in _GENDER_CPS_TO_STRIP])
+    name = _CUSTOM_SEQ_NAMES.get(seq)
+
     return name
-
-  # Single characters that participate in sequences (e.g. fire truck in the
-  # firefighter sequences) should not get converted.  Single characters
-  # are in the custom caps names set but not the other sets.
-  if len(seq) == 1:
-    return None
-
-  name = _CUSTOM_GENDERED_SEQ_NAMES.get(seq)
-  if name:
-    return name
-
-  seq = tuple([cp for cp in seq if cp not in _GENDER_CPS_TO_STRIP])
-  name = _CUSTOM_SEQ_NAMES.get(seq)
-
-  return name
 
 
 def _standard_name(seq):
-  """Use the standard emoji name, with some algorithmic modifications.
+    """Use the standard emoji name, with some algorithmic modifications.
 
-  We want to ignore skin-tone modifiers (but of course if the sequence _is_
-  the skin-tone modifier itself we keep that).  So we strip these so we can
-  start with the generic name ignoring skin tone.
+    We want to ignore skin-tone modifiers (but of course if the sequence _is_
+    the skin-tone modifier itself we keep that).  So we strip these so we can
+    start with the generic name ignoring skin tone.
 
-  Non-emoji that are turned into emoji using the emoji VS have '(emoji) '
-  prepended to them, so strip that.
+    Non-emoji that are turned into emoji using the emoji VS have '(emoji) '
+    prepended to them, so strip that.
 
-  Regional indicator symbol names are a bit long, so shorten them.
+    Regional indicator symbol names are a bit long, so shorten them.
 
-  Regional sequences are assumed to be ok as-is in terms of capitalization and
-  punctuation, so no modifications are applied to them.
+    Regional sequences are assumed to be ok as-is in terms of capitalization and
+    punctuation, so no modifications are applied to them.
 
-  After title-casing we make some English articles/prepositions lower-case
-  again.  We also replace '&' with 'and'; Unicode seems rather fond of
-  ampersand."""
+    After title-casing we make some English articles/prepositions lower-case
+    again.  We also replace '&' with 'and'; Unicode seems rather fond of
+    ampersand."""
 
-  if not unicode_data.is_skintone_modifier(seq[0]):
-    seq = tuple([cp for cp in seq if not unicode_data.is_skintone_modifier(cp)])
-  name = unicode_data.get_emoji_sequence_name(seq)
+    if not unicode_data.is_skintone_modifier(seq[0]):
+        seq = tuple([cp for cp in seq if not unicode_data.is_skintone_modifier(cp)])
+    name = unicode_data.get_emoji_sequence_name(seq)
 
-  if name.startswith('(emoji) '):
-    name = name[8:]
+    if name.startswith("(emoji) "):
+        name = name[8:]
 
-  if len(seq) == 1 and unicode_data.is_regional_indicator(seq[0]):
-    return 'Regional Symbol ' + unicode_data.regional_indicator_to_ascii(seq[0])
+    if len(seq) == 1 and unicode_data.is_regional_indicator(seq[0]):
+        return "Regional Symbol " + unicode_data.regional_indicator_to_ascii(seq[0])
 
-  if (unicode_data.is_regional_indicator_seq(seq) or
-      unicode_data.is_regional_tag_seq(seq)):
+    if unicode_data.is_regional_indicator_seq(seq) or unicode_data.is_regional_tag_seq(
+        seq
+    ):
+        return name
+
+    name = name.title()
+    # Require space delimiting just in case...
+    name = re.sub(r"\s&\s", " and ", name)
+    name = re.sub(
+        # not \b at start because we retain capital at start of phrase
+        r"(\s(:?A|And|From|In|Of|With|For))\b",
+        lambda s: s.group(1).lower(),
+        name,
+    )
+
     return name
-
-  name = name.title()
-  # Require space delimiting just in case...
-  name = re.sub(r'\s&\s', ' and ', name)
-  name = re.sub(
-      # not \b at start because we retain capital at start of phrase
-      r'(\s(:?A|And|From|In|Of|With|For))\b', lambda s: s.group(1).lower(),
-      name)
-
-  return name
 
 
 def _name_data(seq, seq_file):
-  name = _custom_name(seq) or _standard_name(seq)
-  # we don't need canonical sequences
-  sequence = ''.join('&#x%x;' % cp for cp in seq if cp != 0xfe0f)
-  fname = path.basename(seq_file)
-  return fname, sequence, name
+    name = _custom_name(seq) or _standard_name(seq)
+    # we don't need canonical sequences
+    sequence = "".join("&#x%x;" % cp for cp in seq if cp != 0xFE0F)
+    fname = path.basename(seq_file)
+    return fname, sequence, name
 
 
 def generate_names(
-    src_dir, dst_dir, skip_limit=20, omit_groups=None, pretty_print=False,
-    verbose=False):
-  srcdir = tool_utils.resolve_path(src_dir)
-  if not path.isdir(srcdir):
-    print('%s is not a directory' % src_dir, file=sys.stderr)
-    return
+    src_dir, dst_dir, skip_limit=20, omit_groups=None, pretty_print=False, verbose=False
+):
+    srcdir = tool_utils.resolve_path(src_dir)
+    if not path.isdir(srcdir):
+        print("%s is not a directory" % src_dir, file=sys.stderr)
+        return
 
-  if omit_groups:
-    unknown_groups = set(omit_groups) - set(unicode_data.get_emoji_groups())
-    if unknown_groups:
-      print('did not recognize %d group%s: %s' % (
-          len(unknown_groups), '' if len(unknown_groups) == 1 else 's',
-          ', '.join('"%s"' % g for g in omit_groups if g in unknown_groups)), file=sys.stderr)
-      print('valid groups are:\n  %s' % (
-          '\n  '.join(g for g in unicode_data.get_emoji_groups())), file=sys.stderr)
-      return
-    print('omitting %d group%s: %s' % (
-        len(omit_groups), '' if len(omit_groups) == 1 else 's',
-        ', '.join('"%s"' % g for g in omit_groups)))
-  else:
-    # might be None
-    print('keeping all groups')
-    omit_groups = []
+    if omit_groups:
+        unknown_groups = set(omit_groups) - set(unicode_data.get_emoji_groups())
+        if unknown_groups:
+            print(
+                "did not recognize %d group%s: %s"
+                % (
+                    len(unknown_groups),
+                    "" if len(unknown_groups) == 1 else "s",
+                    ", ".join('"%s"' % g for g in omit_groups if g in unknown_groups),
+                ),
+                file=sys.stderr,
+            )
+            print(
+                "valid groups are:\n  %s"
+                % ("\n  ".join(g for g in unicode_data.get_emoji_groups())),
+                file=sys.stderr,
+            )
+            return
+        print(
+            "omitting %d group%s: %s"
+            % (
+                len(omit_groups),
+                "" if len(omit_groups) == 1 else "s",
+                ", ".join('"%s"' % g for g in omit_groups),
+            )
+        )
+    else:
+        # might be None
+        print("keeping all groups")
+        omit_groups = []
 
-  # make sure the destination exists
-  dstdir = tool_utils.ensure_dir_exists(
-      tool_utils.resolve_path(dst_dir))
+    # make sure the destination exists
+    dstdir = tool_utils.ensure_dir_exists(tool_utils.resolve_path(dst_dir))
 
-  # _get_image_data returns canonical cp sequences
-  print('src dir:', srcdir)
-  seq_to_file = generate_emoji_html._get_image_data(srcdir, 'png', 'emoji_u')
-  print('seq to file has %d sequences' % len(seq_to_file))
+    # _get_image_data returns canonical cp sequences
+    print("src dir:", srcdir)
+    seq_to_file = generate_emoji_html._get_image_data(srcdir, "png", "emoji_u")
+    print("seq to file has %d sequences" % len(seq_to_file))
 
-  # Aliases add non-gendered versions using gendered images for the most part.
-  # But when we display the images, we don't distinguish genders in the
-  # naming, we rely on the images-- so these look redundant. So we
-  # intentionally don't generate images for these.
-  # However, the alias file also includes the flag aliases, which we do want,
-  # and it also fails to exclude the unknown flag pua (since it doesn't
-  # map to anything), so we need to adjust for this.
-  canonical_aliases = generate_emoji_html._get_canonical_aliases()
+    # Aliases add non-gendered versions using gendered images for the most part.
+    # But when we display the images, we don't distinguish genders in the
+    # naming, we rely on the images-- so these look redundant. So we
+    # intentionally don't generate images for these.
+    # However, the alias file also includes the flag aliases, which we do want,
+    # and it also fails to exclude the unknown flag pua (since it doesn't
+    # map to anything), so we need to adjust for this.
+    canonical_aliases = generate_emoji_html._get_canonical_aliases()
 
-  aliases = set([
-      cps for cps in canonical_aliases.keys()
-      if not unicode_data.is_regional_indicator_seq(cps)])
-  aliases.add((0xfe82b,))  # unknown flag PUA
-  excluded = aliases | generate_emoji_html._get_canonical_excluded()
+    aliases = set(
+        [
+            cps
+            for cps in canonical_aliases.keys()
+            if not unicode_data.is_regional_indicator_seq(cps)
+        ]
+    )
+    aliases.add((0xFE82B,))  # unknown flag PUA
+    excluded = aliases | generate_emoji_html._get_canonical_excluded()
 
-  # The flag aliases have distinct names, so we _do_ want to show them
-  # multiple times.
-  to_add = {}
-  for seq in canonical_aliases:
-    if unicode_data.is_regional_indicator_seq(seq):
-      replace_seq = canonical_aliases[seq]
-      if seq in seq_to_file:
-        print('warning, alias %s has file %s' % (
-            unicode_data.regional_indicator_seq_to_string(seq),
-            seq_to_file[seq]))
-        continue
-      replace_file = seq_to_file.get(replace_seq)
-      if replace_file:
-        to_add[seq] = replace_file
-  seq_to_file.update(to_add)
+    # The flag aliases have distinct names, so we _do_ want to show them
+    # multiple times.
+    to_add = {}
+    for seq in canonical_aliases:
+        if unicode_data.is_regional_indicator_seq(seq):
+            replace_seq = canonical_aliases[seq]
+            if seq in seq_to_file:
+                print(
+                    "warning, alias %s has file %s"
+                    % (
+                        unicode_data.regional_indicator_seq_to_string(seq),
+                        seq_to_file[seq],
+                    )
+                )
+                continue
+            replace_file = seq_to_file.get(replace_seq)
+            if replace_file:
+                to_add[seq] = replace_file
+    seq_to_file.update(to_add)
 
-  data = []
-  last_skipped_group = None
-  skipcount = 0
-  for group in unicode_data.get_emoji_groups():
-    if group in omit_groups:
-      continue
-    name_data = []
-    for seq in unicode_data.get_emoji_in_group(group):
-      if seq in excluded:
-        continue
-      seq_file = seq_to_file.get(seq, None)
-      if seq_file is None:
-        skipcount += 1
-        if verbose:
-          if group != last_skipped_group:
-            print('group %s' % group)
-            last_skipped_group = group
-          print('  %s (%s)' % (
-              unicode_data.seq_to_string(seq),
-              ', '.join(unicode_data.name(cp, 'x') for cp in seq)))
-        if skip_limit >= 0 and skipcount > skip_limit:
-          raise Exception('skipped too many items')
-      else:
-        name_data.append(_name_data(seq, seq_file))
-    data.append({'category': group, 'emojis': name_data})
+    data = []
+    last_skipped_group = None
+    skipcount = 0
+    for group in unicode_data.get_emoji_groups():
+        if group in omit_groups:
+            continue
+        name_data = []
+        for seq in unicode_data.get_emoji_in_group(group):
+            if seq in excluded:
+                continue
+            seq_file = seq_to_file.get(seq, None)
+            if seq_file is None:
+                skipcount += 1
+                if verbose:
+                    if group != last_skipped_group:
+                        print("group %s" % group)
+                        last_skipped_group = group
+                    print(
+                        "  %s (%s)"
+                        % (
+                            unicode_data.seq_to_string(seq),
+                            ", ".join(unicode_data.name(cp, "x") for cp in seq),
+                        )
+                    )
+                if skip_limit >= 0 and skipcount > skip_limit:
+                    raise Exception("skipped too many items")
+            else:
+                name_data.append(_name_data(seq, seq_file))
+        data.append({"category": group, "emojis": name_data})
 
-  outfile = path.join(dstdir, 'data.json')
-  with open(outfile, 'w') as f:
-    indent = 2 if pretty_print else None
-    separators = None if pretty_print else (',', ':')
-    json.dump(data, f, indent=indent, separators=separators)
-  print('wrote %s' % outfile)
+    outfile = path.join(dstdir, "data.json")
+    with open(outfile, "w") as f:
+        indent = 2 if pretty_print else None
+        separators = None if pretty_print else (",", ":")
+        json.dump(data, f, indent=indent, separators=separators)
+    print("wrote %s" % outfile)
 
 
 def main():
-  DEFAULT_DSTDIR = '[emoji]/emoji'
-  DEFAULT_IMAGEDIR = '[emoji]/build/compressed_pngs'
+    DEFAULT_DSTDIR = "[emoji]/emoji"
+    DEFAULT_IMAGEDIR = "[emoji]/build/compressed_pngs"
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-s', '--srcdir', help='directory containing images (default %s)' %
-      DEFAULT_IMAGEDIR,  metavar='dir', default=DEFAULT_IMAGEDIR)
-  parser.add_argument(
-      '-d', '--dstdir', help='name of destination directory (default %s)' %
-      DEFAULT_DSTDIR, metavar='fname', default=DEFAULT_DSTDIR)
-  parser.add_argument(
-      '-p', '--pretty_print', help='pretty-print json file',
-      action='store_true')
-  parser.add_argument(
-      '-m', '--missing_limit', help='number of missing images before failure '
-      '(default 20), use -1 for no limit', metavar='n', default=20)
-  parser.add_argument(
-      '--omit_groups', help='names of groups to omit (default "Misc, Flags")',
-      metavar='name', default=['Misc', 'Flags'], nargs='*')
-  parser.add_argument(
-      '-v', '--verbose', help='print progress information to stdout',
-      action='store_true')
-  args = parser.parse_args()
-  generate_names(
-      args.srcdir, args.dstdir, args.missing_limit, args.omit_groups,
-      pretty_print=args.pretty_print, verbose=args.verbose)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-s",
+        "--srcdir",
+        help="directory containing images (default %s)" % DEFAULT_IMAGEDIR,
+        metavar="dir",
+        default=DEFAULT_IMAGEDIR,
+    )
+    parser.add_argument(
+        "-d",
+        "--dstdir",
+        help="name of destination directory (default %s)" % DEFAULT_DSTDIR,
+        metavar="fname",
+        default=DEFAULT_DSTDIR,
+    )
+    parser.add_argument(
+        "-p", "--pretty_print", help="pretty-print json file", action="store_true"
+    )
+    parser.add_argument(
+        "-m",
+        "--missing_limit",
+        help="number of missing images before failure "
+        "(default 20), use -1 for no limit",
+        metavar="n",
+        default=20,
+    )
+    parser.add_argument(
+        "--omit_groups",
+        help='names of groups to omit (default "Misc, Flags")',
+        metavar="name",
+        default=["Misc", "Flags"],
+        nargs="*",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="print progress information to stdout",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    generate_names(
+        args.srcdir,
+        args.dstdir,
+        args.missing_limit,
+        args.omit_groups,
+        pretty_print=args.pretty_print,
+        verbose=args.verbose,
+    )
 
 
 if __name__ == "__main__":

--- a/generate_emoji_placeholders.py
+++ b/generate_emoji_placeholders.py
@@ -3,94 +3,103 @@ import os
 from os import path
 import subprocess
 
-OUTPUT_DIR = '/tmp/placeholder_emoji'
+OUTPUT_DIR = "/tmp/placeholder_emoji"
+
 
 def generate_image(name, text):
-  print(name, text.replace('\n', '_'))
-  subprocess.check_call(
-      ['convert', '-size', '100x100', 'label:%s' % text,
-       '%s/%s' % (OUTPUT_DIR, name)])
+    print(name, text.replace("\n", "_"))
+    subprocess.check_call(
+        ["convert", "-size", "100x100", "label:%s" % text, "%s/%s" % (OUTPUT_DIR, name)]
+    )
+
 
 def is_color_patch(cp):
-  return cp >= 0x1f3fb and cp <= 0x1f3ff
+    return cp >= 0x1F3FB and cp <= 0x1F3FF
+
 
 def has_color_patch(values):
-  for v in values:
-    if is_color_patch(v):
-      return True
-  return False
+    for v in values:
+        if is_color_patch(v):
+            return True
+    return False
+
 
 def regional_to_ascii(cp):
-  return unichr(ord('A') + cp - 0x1f1e6)
+    return unichr(ord("A") + cp - 0x1F1E6)
+
 
 def is_flag_sequence(values):
-  if len(values) != 2:
-    return False
-  for v in values:
-    v -= 0x1f1e6
-    if v < 0 or v > 25:
-      return False
-  return True
+    if len(values) != 2:
+        return False
+    for v in values:
+        v -= 0x1F1E6
+        if v < 0 or v > 25:
+            return False
+    return True
+
 
 def is_keycap_sequence(values):
-  return len(values) == 2 and values[1] == 0x20e3
+    return len(values) == 2 and values[1] == 0x20E3
+
 
 def get_keycap_text(values):
-  return '-%c-' % unichr(values[0]) # convert gags on '['
+    return "-%c-" % unichr(values[0])  # convert gags on '['
+
 
 char_map = {
-    0x1f468: 'M',
-    0x1f469: 'W',
-    0x1f466: 'B',
-    0x1f467: 'G',
-    0x2764: 'H', # heavy black heart, no var sel
-    0x1f48b: 'K', # kiss mark
-    0x200D: '-', # zwj placeholder
-    0xfe0f: '-', # variation selector placeholder
-    0x1f441: 'I', # Eye
-    0x1f5e8: 'W', # 'witness' (left speech bubble)
+    0x1F468: "M",
+    0x1F469: "W",
+    0x1F466: "B",
+    0x1F467: "G",
+    0x2764: "H",  # heavy black heart, no var sel
+    0x1F48B: "K",  # kiss mark
+    0x200D: "-",  # zwj placeholder
+    0xFE0F: "-",  # variation selector placeholder
+    0x1F441: "I",  # Eye
+    0x1F5E8: "W",  # 'witness' (left speech bubble)
 }
 
+
 def get_combining_text(values):
-  chars = []
-  for v in values:
-    char = char_map.get(v, None)
-    if not char:
-      return None
-    if char != '-':
-      chars.append(char)
-  return ''.join(chars)
+    chars = []
+    for v in values:
+        char = char_map.get(v, None)
+        if not char:
+            return None
+        if char != "-":
+            chars.append(char)
+    return "".join(chars)
 
 
 if not path.isdir(OUTPUT_DIR):
-  os.makedirs(OUTPUT_DIR)
+    os.makedirs(OUTPUT_DIR)
 
-with open('sequences.txt', 'r') as f:
-  for seq in f:
-    seq = seq.strip()
-    text = None
-    values = [int(code, 16) for code in seq.split('_')]
-    if len(values) == 1:
-      val = values[0]
-      text = '%04X' % val # ensure upper case format
-    elif is_flag_sequence(values):
-      text = ''.join(regional_to_ascii(cp) for cp in values)
-    elif has_color_patch(values):
-      print('skipping color patch sequence %s' % seq)
-    elif is_keycap_sequence(values):
-      text = get_keycap_text(values)
-    else:
-      text = get_combining_text(values)
-      if not text:
-        print('missing %s' % seq)
-
-    if text:
-      if len(text) > 3:
-        if len(text) == 4:
-          hi = text[:2]
-          lo = text[2:]
+with open("sequences.txt", "r") as f:
+    for seq in f:
+        seq = seq.strip()
+        text = None
+        values = [int(code, 16) for code in seq.split("_")]
+        if len(values) == 1:
+            val = values[0]
+            text = "%04X" % val  # ensure upper case format
+        elif is_flag_sequence(values):
+            text = "".join(regional_to_ascii(cp) for cp in values)
+        elif has_color_patch(values):
+            print("skipping color patch sequence %s" % seq)
+        elif is_keycap_sequence(values):
+            text = get_keycap_text(values)
         else:
-          hi = text[:-3]
-          lo = text[-3:]
-        text = '%s\n%s' % (hi, lo)
-      generate_image('emoji_u%s.png' % seq, text)
+            text = get_combining_text(values)
+            if not text:
+                print("missing %s" % seq)
+
+        if text:
+            if len(text) > 3:
+                if len(text) == 4:
+                    hi = text[:2]
+                    lo = text[2:]
+                else:
+                    hi = text[:-3]
+                    lo = text[-3:]
+                text = "%s\n%s" % (hi, lo)
+            generate_image("emoji_u%s.png" % seq, text)

--- a/generate_emoji_thumbnails.py
+++ b/generate_emoji_thumbnails.py
@@ -20,7 +20,6 @@ conventions and writes thumbnails of them into the destination
 directory.  If a file is a target of one or more aliases, creates
 copies named for the aliases."""
 
-
 import argparse
 import collections
 import logging
@@ -34,126 +33,157 @@ import add_aliases
 from nototools import tool_utils
 from nototools import unicode_data
 
-logger = logging.getLogger('emoji_thumbnails')
+logger = logging.getLogger("emoji_thumbnails")
+
 
 def create_thumbnail(src_path, dst_path, crop):
-  # Uses imagemagik
-  # We need images exactly 72x72 in size, with transparent background.
-  # Remove 4-pixel LR margins from 136x128 source images if we crop.
-  if crop:
-    cmd = [
-        'convert', src_path, '-crop', '128x128+4+0!', '-thumbnail', '72x72',
-        'PNG32:' + dst_path]
-  else:
-    cmd = [
-        'convert', '-thumbnail', '72x72', '-gravity', 'center', '-background',
-        'none', '-extent', '72x72', src_path, 'PNG32:' + dst_path]
-  subprocess.check_call(cmd)
+    # Uses imagemagik
+    # We need images exactly 72x72 in size, with transparent background.
+    # Remove 4-pixel LR margins from 136x128 source images if we crop.
+    if crop:
+        cmd = [
+            "convert",
+            src_path,
+            "-crop",
+            "128x128+4+0!",
+            "-thumbnail",
+            "72x72",
+            "PNG32:" + dst_path,
+        ]
+    else:
+        cmd = [
+            "convert",
+            "-thumbnail",
+            "72x72",
+            "-gravity",
+            "center",
+            "-background",
+            "none",
+            "-extent",
+            "72x72",
+            src_path,
+            "PNG32:" + dst_path,
+        ]
+    subprocess.check_call(cmd)
 
 
 def get_inv_aliases():
-  """Return a mapping from target to list of sources for all alias
-  targets in either the default alias table or the unknown_flag alias
-  table."""
+    """Return a mapping from target to list of sources for all alias
+    targets in either the default alias table or the unknown_flag alias
+    table."""
 
-  inv_aliases = collections.defaultdict(list)
+    inv_aliases = collections.defaultdict(list)
 
-  standard_aliases = add_aliases.read_default_emoji_aliases()
-  for k, v in standard_aliases.iteritems():
-    inv_aliases[v].append(k)
+    standard_aliases = add_aliases.read_default_emoji_aliases()
+    for k, v in standard_aliases.iteritems():
+        inv_aliases[v].append(k)
 
-  unknown_flag_aliases = add_aliases.read_emoji_aliases(
-      'unknown_flag_aliases.txt')
-  for k, v in unknown_flag_aliases.iteritems():
-    inv_aliases[v].append(k)
+    unknown_flag_aliases = add_aliases.read_emoji_aliases("unknown_flag_aliases.txt")
+    for k, v in unknown_flag_aliases.iteritems():
+        inv_aliases[v].append(k)
 
-  return inv_aliases
+    return inv_aliases
 
 
 def filename_to_sequence(filename, prefix, suffix):
-  if not filename.startswith(prefix) and filename.endswith(suffix):
-    raise ValueError('bad prefix or suffix: "%s"' % filename)
-  seq_str = filename[len(prefix): -len(suffix)]
-  seq = unicode_data.string_to_seq(seq_str)
-  if not unicode_data.is_cp_seq(seq):
-    raise ValueError('sequence includes non-codepoint: "%s"' % filename)
-  return seq
+    if not filename.startswith(prefix) and filename.endswith(suffix):
+        raise ValueError('bad prefix or suffix: "%s"' % filename)
+    seq_str = filename[len(prefix) : -len(suffix)]
+    seq = unicode_data.string_to_seq(seq_str)
+    if not unicode_data.is_cp_seq(seq):
+        raise ValueError('sequence includes non-codepoint: "%s"' % filename)
+    return seq
 
 
 def sequence_to_filename(seq, prefix, suffix):
-  return ''.join((prefix, unicode_data.seq_to_string(seq), suffix))
+    return "".join((prefix, unicode_data.seq_to_string(seq), suffix))
 
 
 def create_thumbnails_and_aliases(src_dir, dst_dir, crop, dst_prefix):
-  """Creates thumbnails in dst_dir based on sources in src.dir, using
-  dst_prefix. Assumes the source prefix is 'emoji_u' and the common suffix
-  is '.png'."""
+    """Creates thumbnails in dst_dir based on sources in src.dir, using
+    dst_prefix. Assumes the source prefix is 'emoji_u' and the common suffix
+    is '.png'."""
 
-  src_dir = tool_utils.resolve_path(src_dir)
-  if not path.isdir(src_dir):
-    raise ValueError('"%s" is not a directory')
+    src_dir = tool_utils.resolve_path(src_dir)
+    if not path.isdir(src_dir):
+        raise ValueError('"%s" is not a directory')
 
-  dst_dir = tool_utils.ensure_dir_exists(tool_utils.resolve_path(dst_dir))
+    dst_dir = tool_utils.ensure_dir_exists(tool_utils.resolve_path(dst_dir))
 
-  src_prefix = 'emoji_u'
-  suffix = '.png'
+    src_prefix = "emoji_u"
+    suffix = ".png"
 
-  inv_aliases = get_inv_aliases()
+    inv_aliases = get_inv_aliases()
 
-  for src_file in os.listdir(src_dir):
-    try:
-      seq = unicode_data.strip_emoji_vs(
-          filename_to_sequence(src_file, src_prefix, suffix))
-    except ValueError as ve:
-      logger.warning('Error (%s), skipping' % ve)
-      continue
+    for src_file in os.listdir(src_dir):
+        try:
+            seq = unicode_data.strip_emoji_vs(
+                filename_to_sequence(src_file, src_prefix, suffix)
+            )
+        except ValueError as ve:
+            logger.warning("Error (%s), skipping" % ve)
+            continue
 
-    src_path = path.join(src_dir, src_file)
+        src_path = path.join(src_dir, src_file)
 
-    dst_file = sequence_to_filename(seq, dst_prefix, suffix)
-    dst_path = path.join(dst_dir, dst_file)
+        dst_file = sequence_to_filename(seq, dst_prefix, suffix)
+        dst_path = path.join(dst_dir, dst_file)
 
-    create_thumbnail(src_path, dst_path, crop)
-    logger.info('wrote thumbnail%s: %s' % (
-        ' with crop' if crop else '', dst_file))
+        create_thumbnail(src_path, dst_path, crop)
+        logger.info("wrote thumbnail%s: %s" % (" with crop" if crop else "", dst_file))
 
-    for alias_seq in inv_aliases.get(seq, ()):
-      alias_file = sequence_to_filename(alias_seq, dst_prefix, suffix)
-      alias_path = path.join(dst_dir, alias_file)
-      shutil.copy2(dst_path, alias_path)
-      logger.info('wrote alias: %s' % alias_file)
+        for alias_seq in inv_aliases.get(seq, ()):
+            alias_file = sequence_to_filename(alias_seq, dst_prefix, suffix)
+            alias_path = path.join(dst_dir, alias_file)
+            shutil.copy2(dst_path, alias_path)
+            logger.info("wrote alias: %s" % alias_file)
 
 
 def main():
-  SRC_DEFAULT = '[emoji]/build/compressed_pngs'
-  PREFIX_DEFAULT = 'android_'
+    SRC_DEFAULT = "[emoji]/build/compressed_pngs"
+    PREFIX_DEFAULT = "android_"
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-s', '--src_dir', help='source images (default \'%s\')' % SRC_DEFAULT,
-      default=SRC_DEFAULT, metavar='dir')
-  parser.add_argument(
-      '-d', '--dst_dir', help='destination directory', metavar='dir',
-      required=True)
-  parser.add_argument(
-      '-p', '--prefix', help='prefix for thumbnail (default \'%s\')' %
-      PREFIX_DEFAULT, default=PREFIX_DEFAULT, metavar='str')
-  parser.add_argument(
-      '-c', '--crop', help='crop images (will automatically crop if '
-      'src dir is the default)', action='store_true')
-  parser.add_argument(
-      '-v', '--verbose', help='write log output', metavar='level',
-      choices='warning info debug'.split(), const='info',
-      nargs='?')
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-s",
+        "--src_dir",
+        help="source images (default '%s')" % SRC_DEFAULT,
+        default=SRC_DEFAULT,
+        metavar="dir",
+    )
+    parser.add_argument(
+        "-d", "--dst_dir", help="destination directory", metavar="dir", required=True
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        help="prefix for thumbnail (default '%s')" % PREFIX_DEFAULT,
+        default=PREFIX_DEFAULT,
+        metavar="str",
+    )
+    parser.add_argument(
+        "-c",
+        "--crop",
+        help="crop images (will automatically crop if src dir is the default)",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        help="write log output",
+        metavar="level",
+        choices="warning info debug".split(),
+        const="info",
+        nargs="?",
+    )
+    args = parser.parse_args()
 
-  if args.verbose is not None:
-    logging.basicConfig(level=getattr(logging, args.verbose.upper()))
+    if args.verbose is not None:
+        logging.basicConfig(level=getattr(logging, args.verbose.upper()))
 
-  crop = args.crop or (args.src_dir == SRC_DEFAULT)
-  create_thumbnails_and_aliases(
-      args.src_dir, args.dst_dir, crop, args.prefix)
+    crop = args.crop or (args.src_dir == SRC_DEFAULT)
+    create_thumbnails_and_aliases(args.src_dir, args.dst_dir, crop, args.prefix)
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/generate_test_html.py
+++ b/generate_test_html.py
@@ -26,8 +26,9 @@ from fontTools import ttx
 
 import add_svg_glyphs
 
+
 def do_generate_test_html(font_basename, pairs, glyph=None, verbosity=1):
-  header = r"""<!DOCTYPE html>
+    header = r"""<!DOCTYPE html>
 <html>
 <head>
 <meta charset="utf-8">
@@ -77,7 +78,7 @@ function setup() {
 </script>
 </head>"""
 
-  body_head = r"""<body onload="setup();">
+    body_head = r"""<body onload="setup();">
 <p>Test for SVG glyphs in %(font)s.  It uses the proposed
 <a href="http://lists.w3.org/Archives/Public/public-svgopentype/2013Jul/0003.html">SVG-in-OpenType format</a>.
 View using Firefox&nbsp;26 and later.
@@ -87,116 +88,174 @@ View using Firefox&nbsp;26 and later.
 </div>
 <div id='emoji'><p>"""
 
-  body_tail = r"""</div>
+    body_tail = r"""</div>
 </body>
 </html>
 """
 
-  font_name = font_basename + ".woff"
-  html_name = font_basename + "_test.html"
+    font_name = font_basename + ".woff"
+    html_name = font_basename + "_test.html"
 
-  found_initial_glyph = False
-  initial_glyph_str = None;
-  initial_glyph_hex = None;
-  text_parts = []
-  for glyphstr, _ in pairs:
-    name_parts = []
-    hex_parts = []
-    for cp in glyphstr:
-      hex_str = hex(ord(cp))
-      name_parts.append('&#x%s;' % hex_str[2:])
-      hex_parts.append(hex_str)
-    glyph_str = ''.join(name_parts)
+    found_initial_glyph = False
+    initial_glyph_str = None
+    initial_glyph_hex = None
+    text_parts = []
+    for glyphstr, _ in pairs:
+        name_parts = []
+        hex_parts = []
+        for cp in glyphstr:
+            hex_str = hex(ord(cp))
+            name_parts.append("&#x%s;" % hex_str[2:])
+            hex_parts.append(hex_str)
+        glyph_str = "".join(name_parts)
 
-    if not found_initial_glyph:
-      if not glyph or glyph_str == glyph:
-        initial_glyph_str = glyph_str
-        initial_glyph_hex = ' '.join(hex_parts)
-        found_initial_glyph = True
-      elif not initial_glyph_str:
-        initial_glyph_str = glyph_str
-        initial_glyph_hex = ' '.join(hex_parts)
+        if not found_initial_glyph:
+            if not glyph or glyph_str == glyph:
+                initial_glyph_str = glyph_str
+                initial_glyph_hex = " ".join(hex_parts)
+                found_initial_glyph = True
+            elif not initial_glyph_str:
+                initial_glyph_str = glyph_str
+                initial_glyph_hex = " ".join(hex_parts)
 
-    text = '<span>%s</span>' % glyph_str
-    text_parts.append(text)
+        text = "<span>%s</span>" % glyph_str
+        text_parts.append(text)
 
-  if verbosity and glyph and not found_initial_glyph:
-    print("Did not find glyph '%s', using initial glyph '%s'" % (glyph, initial_glyph_str))
-  elif verbosity > 1 and not glyph:
-    print("Using initial glyph '%s'" % initial_glyph_str)
+    if verbosity and glyph and not found_initial_glyph:
+        print(
+            "Did not find glyph '%s', using initial glyph '%s'"
+            % (glyph, initial_glyph_str)
+        )
+    elif verbosity > 1 and not glyph:
+        print("Using initial glyph '%s'" % initial_glyph_str)
 
-  lines = [header % font_name]
-  lines.append(body_head % {'font':font_name, 'glyph':initial_glyph_str,
-                            'glyph_hex':initial_glyph_hex})
-  lines.extend(text_parts) # we'll end up with space between each emoji
-  lines.append(body_tail)
-  output = '\n'.join(lines)
-  with open(html_name, 'w') as fp:
-    fp.write(output)
-  if verbosity:
-    print('Wrote ' + html_name)
+    lines = [header % font_name]
+    lines.append(
+        body_head
+        % {
+            "font": font_name,
+            "glyph": initial_glyph_str,
+            "glyph_hex": initial_glyph_hex,
+        }
+    )
+    lines.extend(text_parts)  # we'll end up with space between each emoji
+    lines.append(body_tail)
+    output = "\n".join(lines)
+    with open(html_name, "w") as fp:
+        fp.write(output)
+    if verbosity:
+        print("Wrote " + html_name)
 
 
 def do_generate_fonts(template_file, font_basename, pairs, reuse=0, verbosity=1):
-  out_woff = font_basename + '.woff'
-  if reuse > 1 and os.path.isfile(out_woff) and os.access(out_woff, os.R_OK):
+    out_woff = font_basename + ".woff"
+    if reuse > 1 and os.path.isfile(out_woff) and os.access(out_woff, os.R_OK):
+        if verbosity:
+            print("Reusing " + out_woff)
+        return
+
+    out_ttx = font_basename + ".ttx"
+    if reuse == 0:
+        add_svg_glyphs.add_image_glyphs(
+            template_file, out_ttx, pairs, verbosity=verbosity
+        )
+    elif verbosity:
+        print("Reusing " + out_ttx)
+
+    quiet = verbosity < 2
+    font = ttx.TTFont(flavor="woff", quiet=quiet)
+    font.importXML(out_ttx, quiet=quiet)
+    font.save(out_woff)
     if verbosity:
-      print('Reusing ' + out_woff)
-    return
-
-  out_ttx = font_basename + '.ttx'
-  if reuse == 0:
-    add_svg_glyphs.add_image_glyphs(template_file, out_ttx, pairs, verbosity=verbosity)
-  elif verbosity:
-    print('Reusing ' + out_ttx)
-
-  quiet=verbosity < 2
-  font = ttx.TTFont(flavor='woff', quiet=quiet)
-  font.importXML(out_ttx, quiet=quiet)
-  font.save(out_woff)
-  if verbosity:
-    print('Wrote ' + out_woff)
+        print("Wrote " + out_woff)
 
 
 def main(argv):
-  usage = """This will search for files that have image_prefix followed by one or more
+    usage = """This will search for files that have image_prefix followed by one or more
       hex numbers (separated by underscore if more than one), and end in ".svg".
       For example, if image_prefix is "icons/u", then files with names like
       "icons/u1F4A9.svg" or "icons/u1F1EF_1F1F5.svg" will be found. It generates
       an SVG font from this, converts it to woff, and also generates an html test
       page containing text for all the SVG glyphs."""
 
-  parser = argparse.ArgumentParser(
-      description='Generate font and html test file.', epilog=usage)
-  parser.add_argument('template_file', help='name of template .ttx file')
-  parser.add_argument('image_prefix', help='location and prefix of image files')
-  parser.add_argument('-i', '--include', help='include files whoses name matches this regex')
-  parser.add_argument('-e', '--exclude', help='exclude files whose name matches this regex')
-  parser.add_argument('-o', '--out_basename', help='base name of (ttx, woff, html) files to generate, '
-                      'defaults to the template base name')
-  parser.add_argument('-g', '--glyph', help='set the initial glyph text (html encoded string), '
-                      'defaults to first glyph')
-  parser.add_argument('-rt', '--reuse_ttx_font', dest='reuse_font', help='use existing ttx font',
-                      default=0, const=1, action='store_const')
-  parser.add_argument('-r', '--reuse_font', dest='reuse_font', help='use existing woff font',
-                      const=2, action='store_const')
-  parser.add_argument('-q', '--quiet', dest='v', help='quiet operation', default=1,
-                      action='store_const', const=0)
-  parser.add_argument('-v', '--verbose', dest='v', help='verbose operation',
-                      action='store_const', const=2)
-  args = parser.parse_args(argv)
+    parser = argparse.ArgumentParser(
+        description="Generate font and html test file.", epilog=usage
+    )
+    parser.add_argument("template_file", help="name of template .ttx file")
+    parser.add_argument("image_prefix", help="location and prefix of image files")
+    parser.add_argument(
+        "-i", "--include", help="include files whoses name matches this regex"
+    )
+    parser.add_argument(
+        "-e", "--exclude", help="exclude files whose name matches this regex"
+    )
+    parser.add_argument(
+        "-o",
+        "--out_basename",
+        help="base name of (ttx, woff, html) files to generate, "
+        "defaults to the template base name",
+    )
+    parser.add_argument(
+        "-g",
+        "--glyph",
+        help="set the initial glyph text (html encoded string), "
+        "defaults to first glyph",
+    )
+    parser.add_argument(
+        "-rt",
+        "--reuse_ttx_font",
+        dest="reuse_font",
+        help="use existing ttx font",
+        default=0,
+        const=1,
+        action="store_const",
+    )
+    parser.add_argument(
+        "-r",
+        "--reuse_font",
+        dest="reuse_font",
+        help="use existing woff font",
+        const=2,
+        action="store_const",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        dest="v",
+        help="quiet operation",
+        default=1,
+        action="store_const",
+        const=0,
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="v",
+        help="verbose operation",
+        action="store_const",
+        const=2,
+    )
+    args = parser.parse_args(argv)
 
-  pairs = add_svg_glyphs.collect_glyphstr_file_pairs(
-    args.image_prefix, 'svg', include=args.include, exclude=args.exclude, verbosity=args.v)
-  add_svg_glyphs.sort_glyphstr_tuples(pairs)
+    pairs = add_svg_glyphs.collect_glyphstr_file_pairs(
+        args.image_prefix,
+        "svg",
+        include=args.include,
+        exclude=args.exclude,
+        verbosity=args.v,
+    )
+    add_svg_glyphs.sort_glyphstr_tuples(pairs)
 
-  out_basename = args.out_basename
-  if not out_basename:
-    out_basename = args.template_file.split('.')[0] # exclude e.g. '.tmpl.ttx'
-    if args.v:
-      print("Output basename is %s." % out_basename)
-  do_generate_fonts(args.template_file, out_basename, pairs, reuse=args.reuse_font, verbosity=args.v)
-  do_generate_test_html(out_basename, pairs, glyph=args.glyph, verbosity=args.v)
+    out_basename = args.out_basename
+    if not out_basename:
+        out_basename = args.template_file.split(".")[0]  # exclude e.g. '.tmpl.ttx'
+        if args.v:
+            print("Output basename is %s." % out_basename)
+    do_generate_fonts(
+        args.template_file, out_basename, pairs, reuse=args.reuse_font, verbosity=args.v
+    )
+    do_generate_test_html(out_basename, pairs, glyph=args.glyph, verbosity=args.v)
 
-if __name__ == '__main__':
-  main(sys.argv[1:])
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/map_pua_emoji.py
+++ b/map_pua_emoji.py
@@ -16,7 +16,7 @@
 
 """Modify an emoji font to map legacy PUA characters to standard ligatures."""
 
-__author__ = 'roozbeh@google.com (Roozbeh Pournader)'
+__author__ = "roozbeh@google.com (Roozbeh Pournader)"
 
 import sys
 import itertools
@@ -29,8 +29,7 @@ import add_emoji_gsub
 
 
 def get_glyph_name_from_gsub(char_seq, font):
-    """Find the glyph name for ligature of a given character sequence from GSUB.
-    """
+    """Find the glyph name for ligature of a given character sequence from GSUB."""
     cmap = font_data.get_cmap(font)
     # FIXME: So many assumptions are made here.
     try:
@@ -39,7 +38,7 @@ def get_glyph_name_from_gsub(char_seq, font):
     except KeyError:
         return None
 
-    for lookup in font['GSUB'].table.LookupList.Lookup:
+    for lookup in font["GSUB"].table.LookupList.Lookup:
         ligatures = lookup.SubTable[0].ligatures
         try:
             for ligature in ligatures[first_glyph]:
@@ -69,6 +68,5 @@ def main(argv):
     add_pua_cmap(argv[1], argv[2])
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main(sys.argv)
-

--- a/materialize_emoji_images.py
+++ b/materialize_emoji_images.py
@@ -16,6 +16,7 @@
 
 """Create a copy of the emoji images that instantiates aliases, etc. as
 symlinks."""
+
 from __future__ import print_function
 
 import argparse
@@ -30,97 +31,106 @@ from nototools import tool_utils
 # copied from third_party/color_emoji/add_glyphs.py
 
 EXTRA_SEQUENCES = {
-    'u1F46A': '1F468_200D_1F469_200D_1F466', # MWB
-    'u1F491': '1F469_200D_2764_FE0F_200D_1F468', # WHM
-    'u1F48F': '1F469_200D_2764_FE0F_200D_1F48B_200D_1F468', # WHKM
+    "u1F46A": "1F468_200D_1F469_200D_1F466",  # MWB
+    "u1F491": "1F469_200D_2764_FE0F_200D_1F468",  # WHM
+    "u1F48F": "1F469_200D_2764_FE0F_200D_1F48B_200D_1F468",  # WHKM
 }
 
 # Flag aliases - from: to
 FLAG_ALIASES = {
-    'BV': 'NO',
-    'CP': 'FR',
-    'HM': 'AU',
-    'SJ': 'NO',
-    'UM': 'US',
+    "BV": "NO",
+    "CP": "FR",
+    "HM": "AU",
+    "SJ": "NO",
+    "UM": "US",
 }
 
-OMITTED_FLAGS = set(
-    'BL BQ DG EA EH FK GF GP GS MF MQ NC PM RE TF WF XK YT'.split())
+OMITTED_FLAGS = set("BL BQ DG EA EH FK GF GP GS MF MQ NC PM RE TF WF XK YT".split())
+
 
 def _flag_str(ris_pair):
-  return '_'.join('%04x' % (ord(cp) - ord('A') +  0x1f1e6)
-                  for cp in ris_pair)
+    return "_".join("%04x" % (ord(cp) - ord("A") + 0x1F1E6) for cp in ris_pair)
+
 
 def _copy_files(src, dst):
-  """Copies files named 'emoji_u*.png' from dst to src, and return a set of
-  the names with 'emoji_u' and the extension stripped."""
-  code_strings = set()
-  tool_utils.check_dir_exists(src)
-  dst = tool_utils.ensure_dir_exists(dst, clean=True)
-  for f in glob.glob(path.join(src, 'emoji_u*.png')):
-    shutil.copy(f, dst)
-    code_strings.add(path.splitext(path.basename(f))[0][7:])
-  return code_strings
+    """Copies files named 'emoji_u*.png' from dst to src, and return a set of
+    the names with 'emoji_u' and the extension stripped."""
+    code_strings = set()
+    tool_utils.check_dir_exists(src)
+    dst = tool_utils.ensure_dir_exists(dst, clean=True)
+    for f in glob.glob(path.join(src, "emoji_u*.png")):
+        shutil.copy(f, dst)
+        code_strings.add(path.splitext(path.basename(f))[0][7:])
+    return code_strings
 
 
 def _alias_people(code_strings, dst):
-  """Create aliases for people in dst, based on code_strings."""
-  for src, ali in sorted(EXTRA_SEQUENCES.items()):
-    if src[1:].lower() in code_strings:
-      src_name = 'emoji_%s.png' % src.lower()
-      ali_name = 'emoji_u%s.png' % ali.lower()
-      print('creating symlink %s -> %s' % (ali_name, src_name))
-      os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
-    else:
-      print('people image %s not found' % src, file=os.stderr)
+    """Create aliases for people in dst, based on code_strings."""
+    for src, ali in sorted(EXTRA_SEQUENCES.items()):
+        if src[1:].lower() in code_strings:
+            src_name = "emoji_%s.png" % src.lower()
+            ali_name = "emoji_u%s.png" % ali.lower()
+            print("creating symlink %s -> %s" % (ali_name, src_name))
+            os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
+        else:
+            print("people image %s not found" % src, file=os.stderr)
 
 
 def _alias_flags(code_strings, dst):
-  for ali, src in sorted(FLAG_ALIASES.items()):
-    src_str = _flag_str(src)
-    if src_str in code_strings:
-      src_name = 'emoji_u%s.png' % src_str
-      ali_name = 'emoji_u%s.png' % _flag_str(ali)
-      print('creating symlink %s (%s) -> %s (%s)' % (ali_name, ali, src_name, src))
-      os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
-    else:
-      print('flag image %s (%s) not found' % (src_name, src), file=os.stderr)
+    for ali, src in sorted(FLAG_ALIASES.items()):
+        src_str = _flag_str(src)
+        if src_str in code_strings:
+            src_name = "emoji_u%s.png" % src_str
+            ali_name = "emoji_u%s.png" % _flag_str(ali)
+            print(
+                "creating symlink %s (%s) -> %s (%s)" % (ali_name, ali, src_name, src)
+            )
+            os.symlink(path.join(dst, src_name), path.join(dst, ali_name))
+        else:
+            print("flag image %s (%s) not found" % (src_name, src), file=os.stderr)
 
 
 def _alias_omitted_flags(code_strings, dst):
-  UNKNOWN_FLAG = 'fe82b'
-  if UNKNOWN_FLAG not in code_strings:
-    print('unknown flag missing', file=os.stderr)
-    return
-  dst_name = 'emoji_u%s.png' % UNKNOWN_FLAG
-  dst_path = path.join(dst, dst_name)
-  for ali in sorted(OMITTED_FLAGS):
-    ali_str = _flag_str(ali)
-    if ali_str in code_strings:
-      print('omitted flag %s has image %s' % (ali, ali_str), file=os.stderr)
-      continue
-    ali_name = 'emoji_u%s.png' % ali_str
-    print('creating symlink %s (%s) -> unknown_flag (%s)' % (
-        ali_str, ali, dst_name))
-    os.symlink(dst_path, path.join(dst, ali_name))
+    UNKNOWN_FLAG = "fe82b"
+    if UNKNOWN_FLAG not in code_strings:
+        print("unknown flag missing", file=os.stderr)
+        return
+    dst_name = "emoji_u%s.png" % UNKNOWN_FLAG
+    dst_path = path.join(dst, dst_name)
+    for ali in sorted(OMITTED_FLAGS):
+        ali_str = _flag_str(ali)
+        if ali_str in code_strings:
+            print("omitted flag %s has image %s" % (ali, ali_str), file=os.stderr)
+            continue
+        ali_name = "emoji_u%s.png" % ali_str
+        print(
+            "creating symlink %s (%s) -> unknown_flag (%s)" % (ali_str, ali, dst_name)
+        )
+        os.symlink(dst_path, path.join(dst, ali_name))
 
 
 def materialize_images(src, dst):
-  code_strings = _copy_files(src, dst)
-  _alias_people(code_strings, dst)
-  _alias_flags(code_strings, dst)
-  _alias_omitted_flags(code_strings, dst)
+    code_strings = _copy_files(src, dst)
+    _alias_people(code_strings, dst)
+    _alias_flags(code_strings, dst)
+    _alias_omitted_flags(code_strings, dst)
+
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-s', '--srcdir', help='path to input sources', metavar='dir',
-      default = 'build/compressed_pngs')
-  parser.add_argument(
-      '-d', '--dstdir', help='destination for output images', metavar='dir')
-  args = parser.parse_args()
-  materialize_images(args.srcdir, args.dstdir)
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-s",
+        "--srcdir",
+        help="path to input sources",
+        metavar="dir",
+        default="build/compressed_pngs",
+    )
+    parser.add_argument(
+        "-d", "--dstdir", help="destination for output images", metavar="dir"
+    )
+    args = parser.parse_args()
+    materialize_images(args.srcdir, args.dstdir)
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()

--- a/strip_vs_from_filenames.py
+++ b/strip_vs_from_filenames.py
@@ -25,64 +25,79 @@ import sys
 selector from the name.  For our emoji image data, this codepoint is not
 relevant."""
 
-EMOJI_VS = 0xfe0f
+EMOJI_VS = 0xFE0F
 
 
 def str_to_seq(seq_str):
-  return tuple([int(s, 16) for s in seq_str.split('_')])
+    return tuple([int(s, 16) for s in seq_str.split("_")])
 
 
 def seq_to_str(seq):
-  return '_'.join('%04x' % cp for cp in seq)
+    return "_".join("%04x" % cp for cp in seq)
 
 
 def strip_vs(seq):
-  return tuple([cp for cp in seq if cp != EMOJI_VS])
+    return tuple([cp for cp in seq if cp != EMOJI_VS])
 
 
 def strip_vs_from_filenames(imagedir, prefix, ext, dry_run=False):
-  prefix_len = len(prefix)
-  suffix_len = len(ext) + 1
-  names = [path.basename(f)
-           for f in glob.glob(
-               path.join(imagedir, '%s*.%s' % (prefix, ext)))]
-  renames = {}
-  for name in names:
-    seq = str_to_seq(name[prefix_len:-suffix_len])
-    if seq and EMOJI_VS in seq:
-      newname = '%s%s.%s' % (prefix, seq_to_str(strip_vs(seq)), ext)
-      if newname in names:
-        print('%s non-vs name %s already exists.' % (
-            name, newname), file=sys.stderr)
-        return
-      renames[name] = newname
+    prefix_len = len(prefix)
+    suffix_len = len(ext) + 1
+    names = [
+        path.basename(f)
+        for f in glob.glob(path.join(imagedir, "%s*.%s" % (prefix, ext)))
+    ]
+    renames = {}
+    for name in names:
+        seq = str_to_seq(name[prefix_len:-suffix_len])
+        if seq and EMOJI_VS in seq:
+            newname = "%s%s.%s" % (prefix, seq_to_str(strip_vs(seq)), ext)
+            if newname in names:
+                print(
+                    "%s non-vs name %s already exists." % (name, newname),
+                    file=sys.stderr,
+                )
+                return
+            renames[name] = newname
 
-  for k, v in renames.iteritems():
-    if dry_run:
-      print('%s -> %s' % (k, v))
-    else:
-      os.rename(path.join(imagedir, k), path.join(imagedir, v))
-  print('renamed %d files in %s' % (len(renames), imagedir))
+    for k, v in renames.iteritems():
+        if dry_run:
+            print("%s -> %s" % (k, v))
+        else:
+            os.rename(path.join(imagedir, k), path.join(imagedir, v))
+    print("renamed %d files in %s" % (len(renames), imagedir))
 
 
 def main():
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '-d', '--imagedir', help='directory containing images to rename',
-      metavar='dir', required=True)
-  parser.add_argument(
-      '-e', '--ext', help='image filename extension (default png)',
-      choices=['ai', 'png', 'svg'], default='png')
-  parser.add_argument(
-      '-p', '--prefix', help='image filename prefix (default emoji_u)',
-      default='emoji_u', metavar='pfx')
-  parser.add_argument(
-      '-n', '--dry_run', help='compute renames and list only',
-      action='store_true')
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-d",
+        "--imagedir",
+        help="directory containing images to rename",
+        metavar="dir",
+        required=True,
+    )
+    parser.add_argument(
+        "-e",
+        "--ext",
+        help="image filename extension (default png)",
+        choices=["ai", "png", "svg"],
+        default="png",
+    )
+    parser.add_argument(
+        "-p",
+        "--prefix",
+        help="image filename prefix (default emoji_u)",
+        default="emoji_u",
+        metavar="pfx",
+    )
+    parser.add_argument(
+        "-n", "--dry_run", help="compute renames and list only", action="store_true"
+    )
 
-  args = parser.parse_args()
-  strip_vs_from_filenames(args.imagedir, args.prefix, args.ext, args.dry_run)
+    args = parser.parse_args()
+    strip_vs_from_filenames(args.imagedir, args.prefix, args.ext, args.dry_run)
 
 
-if __name__ == '__main__':
-  main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
(I should probably split the formatting commit into another PR but i added the thing that does the formatting here...)

this closes #62 by fixing up the source build instructions (changing to Python 3, adding ImageMagick—I didn't bother with `which` because it's most likely already there), and adding a `flake.nix` to make reproduction easier.

And then I just added some formatters in the `flake.nix` (because why not), and ran them...they're [Ruff](https://github.com/astral-sh/ruff), [Mdformat](https://github.com/hukkin/mdformat), [yamlfmt](https://github.com/google/yamlfmt), and [Nixfmt](https://github.com/NixOS/nixfmt).