### PR TITLE
Fix Nix flake on current `nixpkgs-unstable`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,4 +27,3 @@ jobs:
         with:
           name: apple-color-emoji-font
           path: AppleColorEmoji.ttf
-

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1748370509,
+        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
         "type": "github"
       },
       "original": {
@@ -29,11 +29,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1739829690,
-        "narHash": "sha256-mL1szCeIsjh6Khn3nH2cYtwO5YXG6gBiTw1A30iGeDU=",
+        "lastModified": 1748243702,
+        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "3d0579f5cc93436052d94b73925b48973a104204",
+        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,6 +50,7 @@
 
       buildFromSource =
         {
+          lib,
           stdenv,
           python3,
           optipng,
@@ -57,6 +58,7 @@
           pngquant,
           imagemagick,
           which,
+          nototools ? null,
         }:
 
         stdenv.mkDerivation {
@@ -70,16 +72,17 @@
           nativeBuildInputs = [
             which
             (python3.withPackages (
-              python-pkgs: with python-pkgs; [
-                fonttools
-                nototools
+              python-pkgs:
+              [
+                python-pkgs.fonttools
               ]
+              ++ lib.optional (nototools == null) python-pkgs.nototools
             ))
             optipng
             zopfli
             pngquant
             imagemagick
-          ];
+          ] ++ lib.optional (nototools != null) nototools;
 
           installPhase = ''
             runHook preInstall
@@ -101,7 +104,9 @@
       # run `nix develop` to get dropped into a shell with all the dependencies
       # and `nix build` to build from source
       packages = forAllSystems (pkgs: rec {
-        apple-emoji-linux = pkgs.callPackage buildFromSource { };
+        apple-emoji-linux = pkgs.callPackage buildFromSource {
+          nototools = if pkgs ? nototools then pkgs.nototools else null;
+        };
         default = apple-emoji-linux;
       });
     };


### PR DESCRIPTION
NixOS/nixpkgs#410417 moved `nototools` to the top level because it depends on otherwise-unused and deprecated Python library `typed-ast`.

This is a slightly ugly way to handle looking for the package in the right places either way.