### PR TITLE
Re-add updated nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "ttc": "ttc"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "ttc": {
+      "flake": false,
+      "locked": {
+        "path": "./Apple Color Emoji.ttc",
+        "type": "path"
+      },
+      "original": {
+        "path": "./Apple Color Emoji.ttc",
+        "type": "path"
+      },
+      "parent": []
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "Convert Apple Color Emoji (sbix TTC) to CBDT/CBLC TTF for Linux and Windows";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    # Pass your TTC when building the package, e.g.:
+    #   nix build --input ttc /path/to/Apple\ Color\ Emoji.ttc
+    ttc = {
+      url = "./Apple Color Emoji.ttc";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ttc }:
+  flake-utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = import nixpkgs { inherit system; };
+    in
+  {
+    devShells = {
+      default = pkgs.mkShell {
+        nativeBuildInputs = [
+          (pkgs.python313.withPackages (ps: [ ps.fonttools ps.pyyaml ps.uharfbuzz ps.pillow ]))
+        ];
+        shellHook = ''
+          echo "Run: python cli.py -c configs/linux.yaml [--input /path/to/Apple\\ Color\\ Emoji.ttc] [--output output/AppleColorEmoji.ttf]"
+        '';
+      };
+    };
+
+    packages.default = pkgs.stdenv.mkDerivation {
+      pname = "apple-emoji-ttf";
+      version = "0.1.0";
+      src = self;
+
+      nativeBuildInputs = [
+        (pkgs.python313.withPackages (ps: [ ps.fonttools ps.pyyaml ps.uharfbuzz ps.pillow ]))
+      ];
+
+      buildPhase = ''
+        runHook preBuild
+        python cli.py -c configs/linux.yaml --input "${ttc}" --output ./AppleColorEmoji-Linux.ttf
+        python cli.py -c configs/windows.yaml --input "${ttc}" --output ./AppleColorEmoji-Windows.ttf
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p $out/share/fonts/truetype
+        cp ./AppleColorEmoji-Linux.ttf ./AppleColorEmoji-Windows.ttf $out/share/fonts/truetype/
+        runHook postInstall
+      '';
+
+      meta = with pkgs.lib; {
+        description = "Apple Color Emoji as CBDT/CBLC TTF for Linux and Windows";
+        homepage = "https://github.com/samuelngs/apple-emoji-ttf";
+        license = licenses.mit;
+        maintainers = [ ];
+        platforms = platforms.unix;
+      };
+    };
+  });
+}


### PR DESCRIPTION
Closes #125 

Mostly re-implemented the old flake, but cleaned it up and omitted the legacy package/shell files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nix flake configuration now available for building platform-specific emoji font packages (Linux and Windows)
  * Development shell included with necessary build dependencies and tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->