### PR TITLE
fix(linux): set units_per_em 2048 to fix advance widths

### DIFF
--- a/configs/linux.yaml
+++ b/configs/linux.yaml
@@ -15,6 +15,9 @@ bitmap:
   backfill_missing:
     source: 160
 tables:
+  head:
+    units_per_em: 2048
+    mac_style: 0
   drop:
     source_tables: true
     outlines: true


### PR DESCRIPTION
Linux inherited Apple's 800 units/em, breaking terminal cell grids and pango/cairo layout. Mirror the Windows recipe's tables.head block so scale_upem rescales to the standard 2048 em, this also matches Noto, and fixes that stuff.

The build result is on the release on my fork. Works great so far. Size issues seem fixed too.

Tests passed.

------
More info on the problem:

The Linux build inherits Apple's native `unitsPerEm = 800`. That non-standard
value produces incorrect advance widths, which breaks text layout across the
Linux stack:

- **Terminals** (e.g. ghostty) compute a broken cell grid — eaten prompts and
  runaway blank columns.
- **pango/cairo apps** (rofi, rofimoji, LibreOffice) fall back to tofu boxes.
Gecko apps (Firefox/Thunderbird) happen to tolerate it, and Noto (2048 em)
renders everywhere — which points straight at the em scale as the cause.

The build tool already had the fix wired up: `apply_head_policy` in
`tables/head.py` calls fontTools' `scale_upem`, which rescales `head` + `hmtx`
advances coherently and preserves Apple's `morx`. The **Windows** recipe uses it
(`units_per_em: 2048`); the **Linux** recipe just never set a `tables.head`
block, so `apply_head_policy(font, None)` is a no-op and Linux kept 800.

The fix:

This adds the same block to `configs/linux.yaml`. 2048 matches the Windows
recipe and is the standard TrueType em (same as Noto Color Emoji).

Verification:

Rebuilt on macOS from `/System/Library/Fonts/Apple Color Emoji.ttc`:

- `unitsPerEm == 2048` (was 800)
- `CBDT` + `CBLC` present, `glyf` dropped, `macStyle == 0`
- `space` advance rescaled 800 → 2048, family still `Apple Color Emoji`
- `pytest tests/` passes — all 20 fixture emoji render through headless
  Chromium above the 80% similarity threshold.